### PR TITLE
Saving and Loading a Project

### DIFF
--- a/hsproj/mpq_list.go
+++ b/hsproj/mpq_list.go
@@ -1,0 +1,4 @@
+package hsproj
+
+
+

--- a/hsproj/project_state.go
+++ b/hsproj/project_state.go
@@ -1,0 +1,167 @@
+package hsproj
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"errors"
+	"path/filepath"
+	"log"
+)
+
+var ActiveProject *ProjectState
+
+func SetDefaultActiveProject() {
+	ActiveProject = GetEmptyProjectState()
+}
+
+type ProjectState struct {
+	// identification
+	Name       string
+	Version    int
+	FolderPath string
+
+	// state
+	Loaded         bool
+	UnsavedChanges bool
+}
+
+func GetEmptyProjectState() *ProjectState {
+	result := ProjectState{}
+	result.Loaded = false
+	result.Name = "Untitled"
+	result.UnsavedChanges = false
+	return &result
+}
+
+// the savable state is just the info that gets saved to the odproj file
+type projectStateSavable struct {
+	Name    string
+	Version int
+}
+
+func (s *ProjectState) getSavable() projectStateSavable {
+	return projectStateSavable{
+		s.Name,
+		s.Version,
+	}
+}
+
+func (s *projectStateSavable) getStateFromSavable() *ProjectState {
+	result := GetEmptyProjectState()
+	result.Name = s.Name
+	result.Version = s.Version
+	return result;
+}
+
+// errors
+var errProjectStateNotLoaded = errors.New("no project folder is loaded")
+
+
+func LoadProjectStateFromFolder(folderpath string) (*ProjectState, error) {
+	// check if the folderpath contains an odproj file, and if it does
+	// load from that instead 
+	testState, err := LoadProjectStateFromProj(filepath.Join(folderpath, "odproj.json"))
+	if err == nil {
+		return testState, nil
+	}
+
+	result := GetEmptyProjectState()
+	result.Loaded = true
+	result.FolderPath = folderpath
+	err = result.postLoad()
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Project '%s' loaded from '%s'", result.Name, result.FolderPath);
+
+	return result, nil
+}
+
+// load from a odproj file
+func LoadProjectStateFromProj(projpath string) (*ProjectState, error) {
+	odprojJSON, err := ioutil.ReadFile(projpath)
+	if err != nil {
+		return nil, err
+	}
+
+	var psav projectStateSavable
+	err = json.Unmarshal(odprojJSON, &psav)
+	if err != nil {
+		return nil, err
+	}
+
+	result := psav.getStateFromSavable()
+	result.Loaded = true
+	result.FolderPath = filepath.Dir(projpath)
+	err = result.postLoad()
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Project '%s' loaded from '%s'", result.Name, result.FolderPath);
+
+	return result, nil
+}
+
+func (s *ProjectState) postLoad() error {
+	// use this to trigger load for other parts of the project
+
+	// TODO: load mpq list
+
+	return nil
+}
+
+func (s *ProjectState) PromptUnsavedChanges() {
+	if !s.UnsavedChanges {
+		return
+	}
+
+	// TODO: prompt the unsaved changes dialog
+}
+
+func (s *ProjectState) Save() error {
+	if !s.Loaded {
+		return errProjectStateNotLoaded
+	}
+
+	// TODO: check if folderpath is valid
+
+	s.Version += 1
+
+	// save the .odproj file
+	odproj, err := json.MarshalIndent(s.getSavable(), "", " ")
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(s.FolderPath, "odproj.json"), odproj, 0644)
+	if err != nil {
+		return err
+	}
+
+	// TODO: call actual saving code for subcomponents...
+
+	log.Printf("Project '%s' saved in '%s'", s.Name, s.FolderPath);
+	s.UnsavedChanges = false
+	return nil
+}
+
+func (s *ProjectState) SaveAs(newpath string) error {
+	// TODO: check for invalid paths
+
+	s.FolderPath = newpath
+	return s.Save()
+}
+
+func (s *ProjectState) Rename(newname string) error {
+	// TOOD: check for invalid names
+
+	s.Name = newname
+	s.UnsavedChanges = true
+	return nil
+}
+
+func (s *ProjectState) Close() {
+	// discard the project
+}

--- a/hsutil/data_dictionary.go
+++ b/hsutil/data_dictionary.go
@@ -1,0 +1,47 @@
+package hsutil
+
+import (
+	"log"
+	"strconv"
+	"strings"
+)
+
+// DataDictionary represents a data file (Excel)
+type DataDictionary struct {
+	FieldNameLookup map[string]int
+	Data            [][]string
+}
+
+func LoadDataDictionary(text string) *DataDictionary {
+	result := &DataDictionary{}
+	lines := strings.Split(text, "\r\n")
+	fileNames := strings.Split(lines[0], "\t")
+	result.FieldNameLookup = make(map[string]int)
+	for i, fieldName := range fileNames {
+		result.FieldNameLookup[fieldName] = i
+	}
+	result.Data = make([][]string, len(lines)-1)
+	for i, line := range lines[1:] {
+		if len(strings.TrimSpace(line)) == 0 {
+			continue
+		}
+		values := strings.Split(line, "\t")
+		if len(values) != len(result.FieldNameLookup) {
+			continue
+		}
+		result.Data[i] = values
+	}
+	return result
+}
+
+func (v *DataDictionary) GetString(fieldName string, index int) string {
+	return v.Data[index][v.FieldNameLookup[fieldName]]
+}
+
+func (v *DataDictionary) GetNumber(fieldName string, index int) int {
+	result, err := strconv.Atoi(v.GetString(fieldName, index))
+	if err != nil {
+		log.Panic(err)
+	}
+	return result
+}

--- a/hsutil/error_handler.go
+++ b/hsutil/error_handler.go
@@ -1,0 +1,10 @@
+package hsutil
+
+import (
+	"log"
+)
+
+func PopupError(err error) {
+	// TODO
+	log.Println(err)
+}

--- a/hsutil/mpq_path.go
+++ b/hsutil/mpq_path.go
@@ -1,0 +1,6 @@
+package hsutil
+
+type MpqPath struct {
+	MpqName  string
+	FilePath string
+}

--- a/hswindows/datadict_dialog.go
+++ b/hswindows/datadict_dialog.go
@@ -1,0 +1,28 @@
+package hswindows
+
+import (
+	"github.com/OpenDiablo2/HellSpawner/hsutil"
+
+	"github.com/go-gl/glfw/v3.2/glfw"
+	"github.com/golang-ui/nuklear/nk"
+)
+
+type DataDictDialog struct {
+	visible bool
+	data    hsutil.DataDictionary
+}
+
+
+func CreateDataDictDialog(path hsutil.MpqPath) DataDictDialog {
+	result := DataDictDialog{}
+	// todo: here we would set result.data by loading some passed in mpq name + filepath pair
+	return result
+}
+
+func (v *DataDictDialog) Show(ctx *nk.Context) {
+	v.visible = true
+}
+
+func (v *DataDictDialog) Render(win *glfw.Window, ctx *nk.Context) {
+	// todo
+}

--- a/hswindows/main_window.go
+++ b/hswindows/main_window.go
@@ -1,6 +1,9 @@
 package hswindows
 
 import (
+	"github.com/OpenDiablo2/HellSpawner/hsproj"
+	"github.com/OpenDiablo2/HellSpawner/hsutil"
+
 	"github.com/go-gl/glfw/v3.2/glfw"
 	"github.com/golang-ui/nuklear/nk"
 )
@@ -28,6 +31,15 @@ func (v *MainWindow) Render(win *glfw.Window, ctx *nk.Context) {
 			nk.NkLayoutRowDynamic(ctx, 25, 1)
 			if nk.NkMenuItemLabel(ctx, "Open Project Folder...", nk.TextAlignLeft) > 0 {
 				v.openProjectDialog.Show(ctx)
+			}
+			if nk.NkMenuItemLabel(ctx, "Save", nk.TextAlignLeft) > 0 {
+				err := hsproj.ActiveProject.Save()
+				if err != nil {
+					hsutil.PopupError(err)
+				}
+			}
+			if nk.NkMenuItemLabel(ctx, "Save As", nk.TextAlignLeft) > 0 {
+				// TODO
 			}
 			if nk.NkMenuItemLabel(ctx, "Quit", nk.TextAlignLeft) > 0 {
 				win.SetShouldClose(true)

--- a/hswindows/open_project_dialog.go
+++ b/hswindows/open_project_dialog.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"path"
 
+	"github.com/OpenDiablo2/HellSpawner/hsproj"
+	"github.com/OpenDiablo2/HellSpawner/hsutil"
+
 	"github.com/go-gl/glfw/v3.2/glfw"
 	"github.com/golang-ui/nuklear/nk"
 )
@@ -54,6 +57,21 @@ func (v *OpenProjectDialog) Render(win *glfw.Window, ctx *nk.Context) {
 				v.RefreshDirs()
 			}
 		}
+		if nk.NkButtonLabel(ctx, "[Okay]") > 0 {
+			hsproj.ActiveProject.PromptUnsavedChanges()
+			hsproj.ActiveProject.Close()
+
+			newproj, err := hsproj.LoadProjectStateFromFolder(v.currentDir)
+			if err != nil {
+				hsutil.PopupError(err)
+				return
+			}
+
+			hsproj.ActiveProject = newproj
+			v.visible = false
+		}
+	} else {
+		v.visible = false
 	}
 	nk.NkEnd(ctx)
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/OpenDiablo2/HellSpawner/hswindows"
+	"github.com/OpenDiablo2/HellSpawner/hsproj"
 
 	"github.com/golang-ui/nuklear/nk"
 	"github.com/xlab/closer"
@@ -26,7 +27,12 @@ func init() {
 
 var mainWindow hswindows.MainWindow
 
+
+
 func main() {
+	// init project state to an empty state
+	hsproj.SetDefaultActiveProject()
+
 	if err := glfw.Init(); err != nil {
 		closer.Fatalln(err)
 	}


### PR DESCRIPTION
**hsproj:** This is a new module / folder that is focused on holding the data state for the project.

**hsproj/project_state:** Defines a ProjectState struct which contains all the contextual information about the project (and later, probably pointers to the data objects that we load). This includes the Name, Version, FolderPath, and information about the state of the project such as if it is Loaded or if it has UnsavedChanges. 

This struct has saving and loading methods, and currently the only thing saved or loaded is an odproj.json file that persists this info and is created in the folder of choice. When loading a project, you can load from an odproj.json file, or just from a folder (if the folder contains such a file, it will load from that file instead). **We need to create an "Unsaved Changes" dialog..** Additionally, **we need to provide some way to give the project a name.** 

**hsproj/mpq_list:** This is a stub. Soon I will make this, upon loading a project, locate all of the MPQs in that folder.

**hsutil/data_dictionary:** This is a duplicate of the logic from OpenDiablo2's data dictionary. I may change this to just reference that file in the future.

**hsutil/error_handler:** Intended to congregate error handling logic. For non-fatal errors, I have added a PopupError(err error) stub which for now just logs the error but in the future I'd like to display a popup message. Fatal errors can continue being treated as they are currently (log.Fatal(err)).

**hsutil/mpq_path:** Simple struct that represents a mpq name / file path pair. Once a project is loaded, each file in each MPQ can be tracked as an MpqPath. 

**hswindows/datadict_dialog:** This is a stub. Soon I will make this a dialog for viewing an editing a data dictionary file in an MPQ.

**hswindows/main_window:** Added a save and a save as button. Save currently works, but all it does is save an odproj.json file in the folder. **We need a Save As dialog**, currently save as does nothing.

**hswindows/open_project_dialog:** Added an "okay" button that allows you to actually select a folder to load. Additionally, hooked up the logic so that loading actually works, now. **We need to make this dialog prettier.** Additionally, **we should have the program remember the last folder you had opened from previous runs and default to that location.**

**main:** When the program starts, we create an empty ProjectState that is Loaded = false. Basically, all functionality should be disabled until Loaded = true (the user loads a project folder).