### PR TITLE
Remove Listfile Meta File

### DIFF
--- a/hsproj/listfile.go
+++ b/hsproj/listfile.go
@@ -1,59 +1,22 @@
 package hsproj
 
 import (
-	"encoding/json"
 	"path/filepath"
-	"strings"
-	"io/ioutil"
 	"log"
 )
 
 type ListFile struct {
-	MpqName string
 	Files   []ListFilePath
 }
 
 type ListFilePath struct{
-	Name string // note: this is just for display and can be customized
-	Path string // path to the file in the mpq
-}
-
-func getListFilePath(folderpath string, mpqname string) string {
-	return filepath.Join(folderpath, strings.ReplaceAll(mpqname, ".mpq", "_mpq_listfile.json"))
-}
-
-func (v *ListFile) Save(folderpath string) error {
-	lf, err := json.MarshalIndent(v, "", " ")
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(getListFilePath(folderpath, v.MpqName), lf, 0644)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func LoadListFile(folderpath string, mpqname string) (*ListFile, error) {
-	lfJSON, err := ioutil.ReadFile(getListFilePath(folderpath, mpqname))
-	if err != nil {
-		return nil, err
-	}
-
-	var plf ListFile
-	err = json.Unmarshal(lfJSON, &plf)
-	if err != nil {
-		return nil, err
-	}
-
-	return &plf, nil
+	Name string 
+	Path string 
 }
 
 func CreateListFileFromMpq(mpq *MpqInfo) *ListFile {
 	// should return a blank one (as such) if none is found internally or if loading it errors
 	result := ListFile{}
-	result.MpqName = mpq.Name
 	result.Files = make([]ListFilePath, 0)
 
 	// if the mpq has an existing lifefile internally, convert it to our listfile format

--- a/hsproj/mpq_list.go
+++ b/hsproj/mpq_list.go
@@ -65,12 +65,7 @@ func (v *MpqList) Populate(folderpath string) error {
 			newinfo.Name = file.Name()
 
 			// now try to load the listfile
-			lf, lfErr := LoadListFile(folderpath, file.Name())
-			if lfErr != nil {
-				// couldn't load the listfile
-				lf = CreateListFileFromMpq(&newinfo)
-			}
-			newinfo.ListFile = lf
+			newinfo.ListFile = CreateListFileFromMpq(&newinfo)
 
 			v.Mpqs = append(v.Mpqs, newinfo)
 		}
@@ -124,12 +119,6 @@ func (v *MpqList) Save(folderpath string) error {
 
 func (v *MpqInfo) Save(folderpath string) error {
 	log.Printf("Saving MPQ '%s'", v.Name)
-
-	// save the listfile
-	err := v.ListFile.Save(folderpath)
-	if err != nil {
-		return err
-	}
 
 	// TODO: save the mpq data itself
 	return nil


### PR DESCRIPTION
After consideration, not going the meta file route for the listfile and will instead focus on using the internal listfile. This change removes saving / loading the list file meta file. 