### PR TITLE
Fix tree hashing + about window

### DIFF
--- a/hsutil/file_tree.go
+++ b/hsutil/file_tree.go
@@ -13,7 +13,7 @@ type FileTreeNode struct {
 	Children []*FileTreeNode
 }
 
-func BuildTreeWalk(curnode *FileTreeNode, curpath []string, fullpath string) {
+func BuildTreeWalk(curnode *FileTreeNode, curpath []string, fullpath string, prevpaths string) {
 	if len(curpath) == 0 {
 		return
 	}
@@ -21,11 +21,12 @@ func BuildTreeWalk(curnode *FileTreeNode, curpath []string, fullpath string) {
 	// take the next bit off curpath
 	var next string
 	next, curpath = curpath[0], curpath[1:]
+	prevpaths = prevpaths + "\\" + next
 
 	// see if next already exists
 	for _, node := range curnode.Children {
 		if strings.ToLower(node.Name) == strings.ToLower(next) {
-			BuildTreeWalk(node, curpath, fullpath) // node already exists, keep walking
+			BuildTreeWalk(node, curpath, fullpath, prevpaths) // node already exists, keep walking
 			return
 		}
 	}
@@ -62,7 +63,8 @@ func BuildTreeWalk(curnode *FileTreeNode, curpath []string, fullpath string) {
 	if newnode.IsFile { // if it's a file, stop
 		newnode.FullPath = fullpath
 	} else { // otherwise, keep walking
-		BuildTreeWalk(newnode, curpath, fullpath)
+		newnode.FullPath = prevpaths
+		BuildTreeWalk(newnode, curpath, fullpath, prevpaths)
 	}
 }
 
@@ -73,7 +75,7 @@ func BuildFileTreeFromFileList(paths []string) *FileTreeNode {
 	
 	for _, p := range paths {
 		pnames := strings.Split(p, string("\\"))
-		BuildTreeWalk(root, pnames, p)
+		BuildTreeWalk(root, pnames, p, "")
 	}
 
 	return root

--- a/hswindows/about_dialog.go
+++ b/hswindows/about_dialog.go
@@ -38,7 +38,7 @@ func (v *AboutDialog) Render(win *glfw.Window, ctx *nk.Context) {
 	dialogHeight := 400
 	width, height := win.GetSize()
 	bounds := nk.NkRect(float32((width/2)-(dialogWidth/2)), float32((height/2)-(dialogHeight/2)), float32(dialogWidth), float32(dialogHeight))
-	if nk.NkBegin(ctx, "About HellSpawner", bounds, nk.WindowClosable|nk.WindowBorder|nk.WindowMovable|nk.WindowBackground) > 0 {
+	if nk.NkBegin(ctx, "About HellSpawner", bounds, nk.WindowClosable|nk.WindowBorder|nk.WindowMovable) > 0 {
 		nk.NkLayoutRowDynamic(ctx, 256, 1)
 		nk.NkImage(ctx, v.d2Logo)
 		nk.NkLayoutRowDynamic(ctx, 18, 1)

--- a/hswindows/mpqtree_dialog.go
+++ b/hswindows/mpqtree_dialog.go
@@ -151,7 +151,7 @@ func (v *MpqTreeDialog) RenderTree(ctx *nk.Context, node *hsutil.FileTreeNode) {
 			// do something when file is selected
 		}
 	} else {
-		if nk.NkTreePushHashed(ctx, nk.TreeTab, node.Name, nk.Minimized, node.Name, int32(len(node.Name)), 0) > 0 {
+		if nk.NkTreePushHashed(ctx, nk.TreeTab, node.Name, nk.Minimized, node.FullPath, int32(len(node.Name)), 0) > 0 {
 			for _, c := range node.Children {
 				v.RenderTree(ctx, c)
 			}

--- a/hswindows/open_project_dialog.go
+++ b/hswindows/open_project_dialog.go
@@ -68,7 +68,7 @@ func (v *OpenProjectDialog) Render(win *glfw.Window, ctx *nk.Context) {
 				hsutil.PopupError(err)
 				return
 			}
-
+			
 			hsproj.ActiveProject = newproj
 			v.visible = false
 			v.loaded()


### PR DESCRIPTION
1) The tree tabs were not being given appropriate hashes-- each was just its name. This meant that opening "data" in one MPQ opened it in all the others, and closing it closed it in the others. To resolve this, directory nodes now have a valid FullPath (like "\d2data.mpq\data\global\") and this FullPath is used as the hash instead of the name when rendering the tree.

2) Closing the about window, for some reason, made the tree collapse back to root. Removing the `nk.WindowBackground` flag from the about window seems to have resolved this, though it is unclear why.