### PR TITLE
Add Editor System + Text Editor

### DIFF
--- a/hsapp/hseditors/editor_window.go
+++ b/hsapp/hseditors/editor_window.go
@@ -1,0 +1,35 @@
+package hseditors
+
+import (
+	"github.com/OpenDiablo2/HellSpawner/hsinterface"
+
+	"github.com/inkyblackness/imgui-go"
+)
+
+type EditorWindow struct {
+	Editor *hsinterface.UIEditor
+
+	isOpen     bool
+	renderName string
+}
+
+
+func CreateEditorWindow(editor *hsinterface.UIEditor) *EditorWindow {
+	result := &EditorWindow{
+		isOpen: true,
+	}
+	result.Editor = editor
+	result.renderName = "##EditorWindow" + (*editor).RenderName();
+	return result
+}
+
+func (v *EditorWindow) Render() {
+	if imgui.BeginV((*v.Editor).Name()+v.renderName, &v.isOpen, imgui.WindowFlagsNoScrollbar|imgui.WindowFlagsNoScrollWithMouse) {
+		(*v.Editor).Render(imgui.Vec2{X: imgui.WindowWidth(), Y: imgui.WindowHeight()})
+	}
+	imgui.End()
+}
+
+func (v *EditorWindow) IsClosed() bool {
+	return !v.isOpen
+}

--- a/hsapp/hseditors/text_editor.go
+++ b/hsapp/hseditors/text_editor.go
@@ -1,0 +1,75 @@
+package hseditors
+
+import (
+	"github.com/OpenDiablo2/HellSpawner/hsutil"
+	"github.com/OpenDiablo2/HellSpawner/hsproj"
+
+	"github.com/inkyblackness/imgui-go"
+)
+
+type TextEditor struct {
+	FileName string 
+	MpqPath  hsutil.MpqPath
+
+	Text *string
+
+	unsavedChanges bool
+
+	renderName string
+}
+
+func CreateTextEditor(filename string, mpqpath hsutil.MpqPath) *TextEditor {
+	ed := TextEditor{}
+	ed.FileName = filename
+	ed.MpqPath = mpqpath
+	ed.renderName = "TextEditor" + ed.MpqPath.MpqName + ":" + ed.MpqPath.FilePath + ":";
+
+	// load the text itself
+	bytes, err := hsproj.ActiveProject.MpqList.LoadFile(mpqpath)
+	var str string
+	if err == nil {
+		str = string(bytes)
+	} else {
+		hsutil.PopupError(err)
+		str = "Failed to load file"
+	}
+	ed.Text = &str
+
+	return &ed
+}
+
+func (v *TextEditor) Name() string {
+	return v.FileName
+}
+
+func (v *TextEditor) LongName() string {
+	return v.MpqPath.MpqName + " :: " + v.MpqPath.FilePath
+}
+
+func (v *TextEditor) RenderName() string {
+	return v.renderName
+}
+
+func (v *TextEditor) HasUnsavedChanges() bool {
+	return v.unsavedChanges
+}
+
+func (v *TextEditor) Save() {
+	// TODO
+	v.unsavedChanges = false
+}
+
+func (v *TextEditor) editCallback(d imgui.InputTextCallbackData) int32 {
+	v.unsavedChanges = true
+	return 0
+}
+
+func (v *TextEditor) Render(size imgui.Vec2) {
+	//if imgui.BeginChildV(v.renderName + "Child", size, false, imgui.WindowFlagsNoMove|imgui.WindowFlagsNoResize|imgui.WindowFlagsNoCollapse|imgui.WindowFlagsNoSavedSettings|imgui.WindowFlagsNoTitleBar) {
+		imgui.InputTextMultilineV(v.renderName + "InputText", v.Text,
+			imgui.Vec2{X: size.X - 10, Y: size.Y - 30},
+			imgui.InputTextFlagsAllowTabInput|imgui.InputTextFlagsCallbackCharFilter,
+			v.editCallback)
+	//}
+	//imgui.EndChild()
+}

--- a/hsapp/main_window.go
+++ b/hsapp/main_window.go
@@ -2,6 +2,7 @@ package hsapp
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/OpenDiablo2/HellSpawner/hsinterface"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/OpenDiablo2/HellSpawner/hsproj"
 	"github.com/OpenDiablo2/HellSpawner/hsutil"
+	"github.com/OpenDiablo2/HellSpawner/hsapp/hseditors"
 )
 
 var WindowWidth float32
@@ -137,7 +139,17 @@ func (v *MainWindow) RefreshProjectLoaded() {
 }
 
 func (v *MainWindow) OnFileSelected(filename string, mpqpath hsutil.MpqPath) {
+	// try to open an editor based on the file extension
+	var ed hsinterface.UIEditor
+	ed = nil
 
+	if filepath.Ext(mpqpath.FilePath) == ".txt" {
+		ed = hseditors.CreateTextEditor(filename, mpqpath)
+	}
+
+	if ed != nil {
+		v.dynamicWindows = append(v.dynamicWindows, hseditors.CreateEditorWindow(&ed))
+	}
 }
 
 func (v *MainWindow) OnViewMpqFileDetails(mpqpath string) {

--- a/hsinterface/ui_editor.go
+++ b/hsinterface/ui_editor.go
@@ -1,0 +1,12 @@
+package hsinterface
+
+import "github.com/inkyblackness/imgui-go"
+
+type UIEditor interface {
+	Name() string // e.g. for tab display
+	LongName() string // e.g. for window display
+	RenderName() string
+	Render(size imgui.Vec2)
+	Save()
+	HasUnsavedChanges() bool
+}


### PR DESCRIPTION
**Editors:** The system is pretty straightforward. Editors are defined in hsapp/hseditors/ and must implement the `UIEditor` interface (in hsinterface, ui_editor.go). The MainWindow has a function called `OnFileSelected` which is used to create editor windows based on the file's extension. So:

1. Define your editor in hseditors, ensure it follows the UIEditor interface.
2. Add a check in `OnFileSelected` in main_window.go for the relevant filetype, and create your new editor.

**TextEditor:** This update adds the Text Editor as an example of how to use this interface. When you select a .txt file, the text editor is selected by default.

**Future Work:**

- There are numerous issues with the text editor; it has no save button, sometimes the window is very small for some reason that I'm not clear on, the windows can get lost behind the MPQ file tree
- We need to create many kinds of editors
- We need to allow docking the editors into a tabview 