### PR TITLE
 Fix extracting filename

### DIFF
--- a/hsapp/hseditors/text_editor.go
+++ b/hsapp/hseditors/text_editor.go
@@ -8,7 +8,7 @@ import (
 )
 
 type TextEditor struct {
-	FileName string 
+	FileName string
 	MpqPath  hsutil.MpqPath
 
 	Text *string
@@ -22,7 +22,7 @@ func CreateTextEditor(filename string, mpqpath hsutil.MpqPath) *TextEditor {
 	ed := TextEditor{}
 	ed.FileName = filename
 	ed.MpqPath = mpqpath
-	ed.renderName = "TextEditor" + ed.MpqPath.MpqName + ":" + ed.MpqPath.FilePath + ":";
+	ed.renderName = "TextEditor" + ed.MpqPath.MpqName + ":" + ed.MpqPath.FilePath + ":"
 
 	// load the text itself
 	bytes, err := hsproj.ActiveProject.MpqList.LoadFile(mpqpath)

--- a/hsapp/main_window.go
+++ b/hsapp/main_window.go
@@ -1,15 +1,17 @@
 package hsapp
 
 import (
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/inkyblackness/imgui-go"
 
+	"github.com/OpenDiablo2/HellSpawner/hsapp/hseditors"
 	"github.com/OpenDiablo2/HellSpawner/hsinterface"
 	"github.com/OpenDiablo2/HellSpawner/hsproj"
 	"github.com/OpenDiablo2/HellSpawner/hsutil"
-	"github.com/OpenDiablo2/HellSpawner/hsapp/hseditors"
 )
 
 var WindowWidth float32
@@ -161,9 +163,12 @@ func (v *MainWindow) RefreshProjectLoaded() {
 func (v *MainWindow) OnFileSelected(filename string, mpqpath hsutil.MpqPath) {
 	// try to open an editor based on the file extension
 	var ed hsinterface.UIEditor
-	ed = nil
 
-	if filepath.Ext(mpqpath.FilePath) == ".txt" {
+	log.Printf("Loading file '%v' from MPQ '%v'", filename, mpqpath)
+
+	ext := strings.ToLower(filepath.Ext(mpqpath.FilePath))
+	switch ext {
+	case ".txt":
 		ed = hseditors.CreateTextEditor(filename, mpqpath)
 	}
 

--- a/hsutil/file_tree.go
+++ b/hsutil/file_tree.go
@@ -15,10 +15,12 @@ type FileTreeNode struct {
 	Children []*FileTreeNode
 }
 
+// GetMpqPath build MpqPath from node
 func (v *FileTreeNode) GetMpqPath() MpqPath {
-	pnames := strings.Split(v.FullPath, string("\\"))
-	fullminusbase := strings.Join(pnames[1:], "\\")
-	return MpqPath{pnames[0], fullminusbase}
+	// Split the mpq filename from internal path
+	// ex: d2data.mpq/data\global\items\flp2ax.dc6
+	pnames := strings.Split(v.FullPath, "/")
+	return MpqPath{pnames[0], pnames[1]}
 }
 
 func BuildTreeWalk(curnode *FileTreeNode, curpath []string, fullpath string, prevpaths string, id int) int {


### PR DESCRIPTION
`GetMpqPath` was incorectly reading the internal path from the full path.

 ex: For `d2data.mpq/data\global\items\flp2ax.dc6` would result in `d2data.mpq/data` and `global\items\flp2ax.dc6`.
 The filename of the mpq wouldn't match and the fail would not be opened.