### PR TITLE
Fix compilation error

### DIFF
--- a/hswindows/hsmainwindow/main_window.go
+++ b/hswindows/hsmainwindow/main_window.go
@@ -486,8 +486,7 @@ func decodeUTF16(b []byte) (string, error) {
 		return "", fmt.Errorf("Must have even length byte slice")
 	}
 
-	u16s := make([]uint1
-6, 1)
+	u16s := make([]uint16, 1)
 	ret := &bytes.Buffer{}
 	b8buf := make([]byte, 4)
 	lb := len(b)


### PR DESCRIPTION
was getting the below error before this fix

```
# github.com/OpenDiablo2/HellSpawner/hswindows/hsmainwindow
hswindows/hsmainwindow/main_window.go:489:22: missing ',' before newline in argument list
```