### PR TITLE
bugfix: dc6 editor

### DIFF
--- a/hswidget/dc6viewer.go
+++ b/hswidget/dc6viewer.go
@@ -13,10 +13,6 @@ import (
 	"github.com/AllenDang/giu"
 )
 
-const (
-	imageScale = 2
-)
-
 type DC6ViewerState struct {
 	controls struct {
 		direction int32
@@ -55,15 +51,19 @@ func (p *DC6ViewerWidget) Build() {
 		//Prevent multiple invocation to LoadImage.
 		giu.Context.SetState(stateId, &DC6ViewerState{})
 
+		sw := float32(p.dc6.Frames[0].Width)
+		sh := float32(p.dc6.Frames[0].Height)
+		widget = giu.Image(nil, sw, sh)
+
 		rgb := make([]*image2.RGBA, p.dc6.Directions*p.dc6.FramesPerDirection)
 
 		for frameIndex := 0; frameIndex < int(p.dc6.Directions*p.dc6.FramesPerDirection); frameIndex++ {
-			rgb[frameIndex] = image2.NewRGBA(image2.Rect(0, 0, int(p.dc6.Frames[frameIndex].Width*imageScale), int(p.dc6.Frames[frameIndex].Height*imageScale)))
+			rgb[frameIndex] = image2.NewRGBA(image2.Rect(0, 0, int(p.dc6.Frames[frameIndex].Width), int(p.dc6.Frames[frameIndex].Height)))
 			decodedFrame := p.dc6.DecodeFrame(frameIndex)
 
-			for y := 0; y < int(p.dc6.Frames[frameIndex].Height*imageScale); y++ {
-				for x := 0; x < int(p.dc6.Frames[frameIndex].Width*imageScale); x++ {
-					idx := (x / imageScale) + ((y / imageScale) * int(p.dc6.Frames[frameIndex].Width))
+			for y := 0; y < int(p.dc6.Frames[frameIndex].Height); y++ {
+				for x := 0; x < int(p.dc6.Frames[frameIndex].Width); x++ {
+					idx := x + (y * int(p.dc6.Frames[frameIndex].Width))
 					val := decodedFrame[idx]
 					rgb[frameIndex].Set(x, y, color.RGBA{R: val, G: val, B: val, A: 255})
 				}
@@ -85,8 +85,15 @@ func (p *DC6ViewerWidget) Build() {
 		widget.Build()
 	} else {
 		viewerState := state.(*DC6ViewerState)
+
+		imageScale := uint32(viewerState.controls.scale)
 		curFrameIndex := int(viewerState.controls.frame) + (int(viewerState.controls.direction) * int(p.dc6.FramesPerDirection))
 
+		if imageScale < 1 {
+			imageScale = 1
+		}
+
+		giu.Context.GetRenderer().SetTextureMagFilter(giu.TextureFilterNearest)
 		var widget *giu.ImageWidget
 		if viewerState.textures == nil || len(viewerState.textures) <= curFrameIndex || viewerState.textures[curFrameIndex] == nil {
 			widget = giu.Image(nil, 32, 32)
@@ -96,19 +103,25 @@ func (p *DC6ViewerWidget) Build() {
 		}
 
 		giu.Layout{
-			giu.Label(fmt.Sprintf("Version: %v", p.dc6.Version)),
-			giu.Label(fmt.Sprintf("Flags: %b", int64(p.dc6.Flags))),
-			giu.Label(fmt.Sprintf("Encoding: %v", p.dc6.Encoding)),
-			giu.Label(fmt.Sprintf("Directions: %v", p.dc6.Directions)),
-			giu.Label(fmt.Sprintf("Frames per Direction: %v", p.dc6.FramesPerDirection)),
+			giu.Label(fmt.Sprintf(
+				"Version: %v\t Flags: %b\t Encoding: %v\t",
+				p.dc6.Version,
+				int64(p.dc6.Flags),
+				p.dc6.Encoding,
+			)),
+			giu.Label(fmt.Sprintf("Directions: %v\tFrames per Direction: %v", p.dc6.Directions, p.dc6.FramesPerDirection)),
 			giu.Custom(func() {
-				//imgui.Text(fmt.Sprintf("%v", p.path))
 				imgui.BeginGroup()
-				imgui.SliderInt("Direction", &viewerState.controls.direction, 0, int32(p.dc6.Directions-1))
-				imgui.SliderInt("Frames", &viewerState.controls.frame, 0, int32(p.dc6.FramesPerDirection-1))
-				//imgui.SliderFloat("Scale", &viewerState.controls.scale, 1, 5)
-				imgui.EndGroup()
+				if p.dc6.Directions > 1 {
+					imgui.SliderInt("Direction", &viewerState.controls.direction, 0, int32(p.dc6.Directions-1))
+				}
 
+				if p.dc6.FramesPerDirection > 1 {
+					imgui.SliderInt("Frames", &viewerState.controls.frame, 0, int32(p.dc6.FramesPerDirection-1))
+				}
+
+				imgui.SliderFloat("Scale", &viewerState.controls.scale, 1, 8)
+				imgui.EndGroup()
 			}),
 			giu.Separator(),
 			widget,


### PR DESCRIPTION
* removed constant scale of `2`, re-enabled scale select widget
* only render direction select widget if more than 1 direction
* only render frame select widget if more than 1 frame
* reduce vertical size of displayed dc6 info
* set image filter to nearest, remove anti-aliasing when scaled >1