### PR TITLE
We can't load textures before MasterWindow.Run

### DIFF
--- a/hscommon/textureloader.go
+++ b/hscommon/textureloader.go
@@ -15,7 +15,7 @@ type TextureLoadRequestItem struct {
 	callback func(*g.Texture)
 }
 
-var canLoadTextures = true
+var canLoadTextures = false
 var mutex = &sync.Mutex{}
 var loadQueue = goconcurrentqueue.NewFIFO()
 


### PR DESCRIPTION
Default canLoadTextures to false to avoid a race.