### PR TITLE
Disable MPQ explorer when no project loaded

### DIFF
--- a/hsapp/menubar.go
+++ b/hsapp/menubar.go
@@ -59,7 +59,7 @@ func (a *App) buildViewMenu() g.Layout {
 
 	result = append(result, g.Menu("Tool Windows").Layout(g.Layout{
 		g.MenuItem("Project Explorer").Selected(a.projectExplorer.Visible).Enabled(true).OnClick(a.toggleProjectExplorer),
-		g.MenuItem("MPQ Explorer").Selected(a.mpqExplorer.Visible).Enabled(true).OnClick(a.toggleMPQExplorer),
+		g.MenuItem("MPQ Explorer").Selected(a.mpqExplorer.Visible).Enabled(a.project != nil).OnClick(a.toggleMPQExplorer),
 	}))
 
 	if len(a.editors) == 0 {


### PR DESCRIPTION
Otherwise it crashes when opening it.