### PR TITLE
Refactored Editor interface, minor change to PathEntry

### DIFF
--- a/hsapp/app.go
+++ b/hsapp/app.go
@@ -183,7 +183,6 @@ func (a *App) openEditor(path *hscommon.PathEntry) {
 		}
 
 		a.editors = append(a.editors, editor)
-		editor.SetId(path.GetUniqueId())
 		editor.Show()
 	}()
 }

--- a/hscommon/editorwindow.go
+++ b/hscommon/editorwindow.go
@@ -6,7 +6,6 @@ type EditorWindow interface {
 	GetWindowTitle() string
 	Show()
 	IsVisible() bool
-	SetId(id string)
 	GetId() string
 	BringToFront()
 }

--- a/hscommon/pathentry.go
+++ b/hscommon/pathentry.go
@@ -12,9 +12,9 @@ const (
 	// PathEntrySourceProject represents a PathEntry that is relative to the project.
 	PathEntrySourceProject
 
-	// PathEntryCoalesced represents a PathEntry that is based on the coalesced view of
-	// the project and all MPQs (Project first, then MPQs based on load order).
-	PathEntryCoalesced
+	// PathEntryVirtual represents a PathEntry that is based on the composite view of
+	// the project directory and all MPQs (Project first, then MPQs based on load order).
+	PathEntryVirtual
 )
 
 // PathEntry defines a file/folder

--- a/hswindow/hseditor/editor.go
+++ b/hswindow/hseditor/editor.go
@@ -1,11 +1,14 @@
 package hseditor
 
-import "github.com/OpenDiablo2/HellSpawner/hswindow"
+import (
+	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hswindow"
+)
 
 type Editor struct {
 	hswindow.Window
+	Path *hscommon.PathEntry
 
-	id      string
 	ToFront bool
 }
 
@@ -13,14 +16,18 @@ func (e *Editor) IsVisible() bool {
 	return e.Visible
 }
 
-func (e *Editor) SetId(id string) {
-	e.id = id
+func (e *Editor) GetId() string {
+	return e.Path.GetUniqueId()
 }
 
-func (e *Editor) GetId() string {
-	return e.id
+func (e *Editor) GetWindowTitle() string {
+	return e.Path.Name + "##" + e.GetId()
 }
 
 func (e *Editor) BringToFront() {
 	e.ToFront = true
+}
+
+func (e *Editor) Cleanup() {
+	e.Visible = false
 }

--- a/hswindow/hseditor/hscofeditor/cof_editor.go
+++ b/hswindow/hseditor/hscofeditor/cof_editor.go
@@ -1,8 +1,6 @@
 package hscofeditor
 
 import (
-	"path/filepath"
-
 	g "github.com/AllenDang/giu"
 	"github.com/AllenDang/giu/imgui"
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
@@ -19,25 +17,17 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow,
 	}
 
 	result := &COFEditor{
-		path: filepath.Base(pathEntry.FullPath),
-		cof:  cof,
+		cof: cof,
 	}
+
+	result.Path = pathEntry
 
 	return result, nil
 }
 
 type COFEditor struct {
 	hseditor.Editor
-	path string
-	cof  *d2cof.COF
-}
-
-func (e *COFEditor) GetWindowTitle() string {
-	return e.path + "##" + e.GetId()
-}
-
-func (e *COFEditor) Cleanup() {
-	e.Visible = false
+	cof *d2cof.COF
 }
 
 func (e *COFEditor) Render() {
@@ -51,6 +41,6 @@ func (e *COFEditor) Render() {
 	}
 
 	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Layout(g.Layout{
-		hswidget.COFViewer(e.path, e.cof),
+		hswidget.COFViewer(e.Path.GetUniqueId(), e.cof),
 	})
 }

--- a/hswindow/hseditor/hsdc6editor/dc6_editor.go
+++ b/hswindow/hseditor/hsdc6editor/dc6_editor.go
@@ -1,8 +1,6 @@
 package hsdc6editor
 
 import (
-	"path/filepath"
-
 	g "github.com/AllenDang/giu"
 	"github.com/AllenDang/giu/imgui"
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
@@ -18,30 +16,18 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow,
 		return nil, err
 	}
 
-	//numFrames := dc6.Directions * dc6.FramesPerDirection
-
 	result := &DC6Editor{
-		path: filepath.Base(pathEntry.FullPath),
-		dc6:  dc6,
-		//decodedFrames: make([][]byte, numFrames),
-		//textures:      make([]*g.Texture, numFrames),
+		dc6: dc6,
 	}
+
+	result.Path = pathEntry
 
 	return result, nil
 }
 
 type DC6Editor struct {
 	hseditor.Editor
-	path string
-	dc6  *d2dc6.DC6
-}
-
-func (e *DC6Editor) GetWindowTitle() string {
-	return e.path + "##" + e.GetId()
-}
-
-func (e *DC6Editor) Cleanup() {
-	e.Visible = false
+	dc6 *d2dc6.DC6
 }
 
 func (e *DC6Editor) Render() {
@@ -55,7 +41,7 @@ func (e *DC6Editor) Render() {
 	}
 
 	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Layout(g.Layout{
-		hswidget.DC6Viewer(e.path, e.dc6),
+		hswidget.DC6Viewer(e.Path.GetUniqueId(), e.dc6),
 	})
 
 }

--- a/hswindow/hseditor/hsdcceditor/dcc_editor.go
+++ b/hswindow/hseditor/hsdcceditor/dcc_editor.go
@@ -1,8 +1,6 @@
 package hsdcceditor
 
 import (
-	"path/filepath"
-
 	g "github.com/AllenDang/giu"
 	"github.com/AllenDang/giu/imgui"
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
@@ -18,30 +16,18 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow,
 		return nil, err
 	}
 
-	//numFrames := dcc.Directions * dcc.FramesPerDirection
-
 	result := &DCCEditor{
-		path: filepath.Base(pathEntry.FullPath),
-		dcc:  dcc,
-		//decodedFrames: make([][]byte, numFrames),
-		//textures:      make([]*g.Texture, numFrames),
+		dcc: dcc,
 	}
+
+	result.Path = pathEntry
 
 	return result, nil
 }
 
 type DCCEditor struct {
 	hseditor.Editor
-	path string
-	dcc  *d2dcc.DCC
-}
-
-func (e *DCCEditor) GetWindowTitle() string {
-	return e.path + "##" + e.GetId()
-}
-
-func (e *DCCEditor) Cleanup() {
-	e.Visible = false
+	dcc *d2dcc.DCC
 }
 
 func (e *DCCEditor) Render() {
@@ -55,7 +41,7 @@ func (e *DCCEditor) Render() {
 	}
 
 	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Layout(g.Layout{
-		hswidget.DCCViewer(e.path, e.dcc),
+		hswidget.DCCViewer(e.Path.GetUniqueId(), e.dcc),
 	})
 
 }

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -17,25 +17,17 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow,
 	}
 
 	result := &DT1Editor{
-		path: pathEntry.FullPath,
-		dt1:  dt1,
+		dt1: dt1,
 	}
+
+	result.Path = pathEntry
 
 	return result, nil
 }
 
 type DT1Editor struct {
 	hseditor.Editor
-	path string
-	dt1  *d2dt1.DT1
-}
-
-func (e *DT1Editor) GetWindowTitle() string {
-	return e.path + "##" + e.GetId()
-}
-
-func (e *DT1Editor) Cleanup() {
-	e.Visible = false
+	dt1 *d2dt1.DT1
 }
 
 func (e *DT1Editor) Render() {
@@ -52,5 +44,5 @@ func (e *DT1Editor) Render() {
 		IsOpen(&e.Visible).
 		Flags(g.WindowFlagsAlwaysAutoResize).
 		Pos(360, 30).
-		Layout(g.Layout{hswidget.DT1Viewer(e.path, e.dt1)})
+		Layout(g.Layout{hswidget.DT1Viewer(e.Path.GetUniqueId(), e.dt1)})
 }

--- a/hswindow/hseditor/hsfonteditor/fonteditor.go
+++ b/hswindow/hseditor/hsfonteditor/fonteditor.go
@@ -9,22 +9,12 @@ import (
 
 type FontEditor struct {
 	hseditor.Editor
-
-	pathEntry *hscommon.PathEntry
-}
-
-func (e *FontEditor) Cleanup() {
-
-}
-
-func (e *FontEditor) GetWindowTitle() string {
-	return e.pathEntry.Name + "##" + e.GetId()
 }
 
 func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
-	result := &FontEditor{
-		pathEntry: pathEntry,
-	}
+	result := &FontEditor{}
+
+	result.Path = pathEntry
 
 	return result, nil
 }

--- a/hswindow/hseditor/hspaletteeditor/palette_editor.go
+++ b/hswindow/hseditor/hspaletteeditor/palette_editor.go
@@ -1,8 +1,6 @@
 package hspaletteeditor
 
 import (
-	"path/filepath"
-
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hswidget"
 
@@ -17,7 +15,6 @@ import (
 type PaletteEditor struct {
 	hseditor.Editor
 	palette d2interface.Palette
-	path    string
 }
 
 func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
@@ -27,15 +24,12 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow,
 	}
 
 	result := &PaletteEditor{
-		path:    filepath.Base(pathEntry.FullPath),
 		palette: palette,
 	}
 
-	return result, nil
-}
+	result.Path = pathEntry
 
-func (e *PaletteEditor) GetWindowTitle() string {
-	return e.path + "##" + e.GetId()
+	return result, nil
 }
 
 func (e *PaletteEditor) Render() {
@@ -51,8 +45,4 @@ func (e *PaletteEditor) Render() {
 	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Pos(360, 30).Layout(g.Layout{
 		hswidget.PaletteGrid(e.GetId()+"_grid", e.palette.GetColors()),
 	})
-}
-
-func (e *PaletteEditor) Cleanup() {
-	e.Visible = false
 }

--- a/hswindow/hseditor/hssoundeditor/soundeditor.go
+++ b/hswindow/hseditor/hssoundeditor/soundeditor.go
@@ -27,13 +27,6 @@ type SoundEditor struct {
 	file     string
 }
 
-func (s *SoundEditor) Cleanup() {
-	speaker.Lock()
-	s.control.Paused = true
-	s.streamer.Close()
-	speaker.Unlock()
-}
-
 func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
 	streamer, format, err := wav.Decode(bytes.NewReader(*data))
 
@@ -82,8 +75,12 @@ func (s *SoundEditor) Render() {
 	})
 }
 
-func (s *SoundEditor) GetWindowTitle() string {
-	return s.file + "##" + s.GetId()
+func (s *SoundEditor) Cleanup() {
+	speaker.Lock()
+	s.control.Paused = true
+	s.streamer.Close()
+	s.Editor.Cleanup()
+	speaker.Unlock()
 }
 
 func (s *SoundEditor) play() {

--- a/hswindow/hseditor/hstexteditor/texteditor.go
+++ b/hswindow/hseditor/hstexteditor/texteditor.go
@@ -1,7 +1,6 @@
 package hstexteditor
 
 import (
-	"path/filepath"
 	"strings"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
@@ -15,25 +14,14 @@ import (
 type TextEditor struct {
 	hseditor.Editor
 
-	//fontFixed imgui.Font
-	file      string
 	text      string
 	tableView bool
 	tableRows g.Rows
 	columns   int
 }
 
-func (e *TextEditor) Cleanup() {
-
-}
-
-func (e *TextEditor) GetWindowTitle() string {
-	return e.file + "##" + e.GetId()
-}
-
 func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
 	result := &TextEditor{
-		file: filepath.Base(pathEntry.FullPath),
 		text: string(*data),
 	}
 


### PR DESCRIPTION
* Minor edit to PathEntry, changed word `Coalesced` to `Virtual`
throughout
* Removed unused method `SetID` from `EditorWindow` interface
* Moved all path-related fields out of concrete editor implementations
and into the generic `Editor`
* Moved the `Cleanup` and `GetWindowTitle` methods out of the concrete
editor implementations and into the generic `Editor`