### PR TITLE
Use file name as default project name

### DIFF
--- a/hscommon/hsproject/project.go
+++ b/hscommon/hsproject/project.go
@@ -34,13 +34,15 @@ type Project struct {
 }
 
 func CreateNew(fileName string) (*Project, error) {
+	defaultProjectName := filepath.Base(fileName)
+
 	if strings.ToLower(filepath.Ext(fileName)) != ".hsp" {
 		fileName += ".hsp"
 	}
 
 	result := &Project{
 		filePath:       fileName,
-		ProjectName:    "Untitled Project",
+		ProjectName:    defaultProjectName,
 		pathEntryCache: nil,
 	}
 


### PR DESCRIPTION
The default project name was "Untitled Project", this just makes it use the chosen file name (minus the ".hsp") as the default project name.