### PR TITLE
Fix dt1 variant display

### DIFF
--- a/hswidget/dt1viewer.go
+++ b/hswidget/dt1viewer.go
@@ -173,6 +173,7 @@ func (p *DT1ViewerWidget) makeTileTextures() {
 		group := make([]map[string]*giu.Texture, len(state.tileGroups[groupIdx]))
 
 		for variantIdx := range state.tileGroups[groupIdx] {
+			variantIdx := variantIdx
 			tile := state.tileGroups[groupIdx][variantIdx]
 
 			floorPix, wallPix := p.makePixelBuffer(tile)


### PR DESCRIPTION
Closes #120 

The index from the for loop was not getting passed properly into the callback function for creating the texture