### PR TITLE
context menu in main menu bar

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,6 @@ github.com/JoshVarga/blast v0.0.0-20180421040937-681c804fb9f0 h1:tDnuU0igiBiQFjs
 github.com/JoshVarga/blast v0.0.0-20180421040937-681c804fb9f0/go.mod h1:h/5OEGj4G+fpYxluLjSMZbFY011ZxAntO98nCl8mrCs=
 github.com/OpenDiablo2/OpenDiablo2 v0.0.0-20210113003256-845abcae0faf h1:lOICf3azuupncMGo1jVpTmt7xLdT5muBONs/efUDAhQ=
 github.com/OpenDiablo2/OpenDiablo2 v0.0.0-20210113003256-845abcae0faf/go.mod h1:3JsaDhsHD+3mmG/WLLct2Zy1HjXS39jsyLPFbgRkbN0=
-github.com/OpenDiablo2/OpenDiablo2 v0.0.0-20210113210205-9f5cde36df89 h1:A50Xu8c67B3Uxm0Qtz6TYD0zLPk9javIJuFccC05iWo=
 github.com/OpenDiablo2/dialog v0.0.0-20201230220514-26162241209f h1:pvMvvC9qn9EaHDbiCgblnrL4iyvwchcMKO81kSnlEsc=
 github.com/OpenDiablo2/dialog v0.0.0-20201230220514-26162241209f/go.mod h1:pVhjsSdbHVR9+2HBRkrfvlZCmjC+jRhGjjKM3uYlfWY=
 github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf h1:FPsprx82rdrX2jiKyS17BH6IrTmUBYqZa/CXT4uvb+I=

--- a/hsapp/app.go
+++ b/hsapp/app.go
@@ -46,11 +46,16 @@ type App struct {
 
 	editors            []hscommon.EditorWindow
 	editorConstructors map[hsfiletypes.FileType]func(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error)
+	focusedEditor      hscommon.EditorWindow
 
 	fontFixed         imgui.Font
 	fontFixedSmall    imgui.Font
 	diabloBoldFont    imgui.Font
 	diabloRegularFont imgui.Font
+}
+
+func (a *App) FocusOn(editor hscommon.EditorWindow) {
+	a.focusedEditor = editor
 }
 
 func Create() (*App, error) {
@@ -87,8 +92,17 @@ func (a *App) render() {
 
 	idx := 0
 	for idx < len(a.editors) {
+		if a.editors[idx].IsFocused() {
+			a.FocusOn(a.editors[idx])
+		}
+
 		if !a.editors[idx].IsVisible() {
 			a.editors[idx].Cleanup()
+
+			if a.focusedEditor == a.editors[idx] {
+				a.focusedEditor = nil
+			}
+
 			a.editors = append(a.editors[:idx], a.editors[idx+1:]...)
 			continue
 		}
@@ -105,7 +119,6 @@ func (a *App) render() {
 
 	g.Update()
 	hscommon.ResumeLoadingTextures()
-
 }
 
 func (a *App) setupFonts() {
@@ -193,6 +206,7 @@ func (a *App) openEditor(path *hscommon.PathEntry) {
 		}
 
 		a.editors = append(a.editors, editor)
+		a.focusedEditor = editor
 		editor.Show()
 	}()
 }
@@ -257,4 +271,8 @@ func (a *App) reloadAuxiliaryMPQs() {
 
 func (a *App) toggleProjectExplorer() {
 	a.projectExplorer.ToggleVisibility()
+}
+
+func (a *App) SetFocusedEditor(e hscommon.EditorWindow) {
+	a.focusedEditor = e
 }

--- a/hsapp/menubar.go
+++ b/hsapp/menubar.go
@@ -14,7 +14,7 @@ import (
 func (a *App) renderMainMenuBar() {
 	projectOpened := a.project != nil
 
-	g.MainMenuBar().Layout(g.Layout{
+	menuLayout := g.Layout{
 		g.Menu("File##MainMenuFile").Layout(g.Layout{
 			g.Menu("New##MainMenuFileNew").Layout(g.Layout{
 				g.MenuItem("Project...##MainMenuFileNewProject").OnClick(a.onNewProjectClicked),
@@ -52,7 +52,15 @@ func (a *App) renderMainMenuBar() {
 		g.Menu("Help").Layout(g.Layout{
 			g.MenuItem("About HellSpawner...##MainMenuHelpAbout").OnClick(a.onHelpAboutClicked),
 		}),
-	}).Build()
+	}
+
+	if a.focusedEditor != nil {
+		a.focusedEditor.UpdateMainMenuLayout(&menuLayout)
+	}
+
+	menuBar := g.MainMenuBar().Layout(menuLayout)
+
+	menuBar.Build()
 }
 
 func (a *App) buildViewMenu() g.Layout {

--- a/hscommon/editorwindow.go
+++ b/hscommon/editorwindow.go
@@ -2,10 +2,13 @@ package hscommon
 
 type EditorWindow interface {
 	Renderable
+	MainMenuUpdater
+	FocusController
 
 	GetWindowTitle() string
 	Show()
 	IsVisible() bool
+	IsFocused() bool
 	GetId() string
 	BringToFront()
 }

--- a/hscommon/main_menu_updater.go
+++ b/hscommon/main_menu_updater.go
@@ -1,0 +1,7 @@
+package hscommon
+
+import "github.com/AllenDang/giu"
+
+type MainMenuUpdater interface {
+	UpdateMainMenuLayout(layout *giu.Layout)
+}

--- a/hscommon/window_focuser.go
+++ b/hscommon/window_focuser.go
@@ -1,0 +1,9 @@
+package hscommon
+
+type EditorFocuser interface {
+	FocusOn(editor EditorWindow)
+}
+
+type FocusController interface {
+	Control(focuser EditorFocuser)
+}

--- a/hswindow/hseditor/editor.go
+++ b/hswindow/hseditor/editor.go
@@ -7,13 +7,23 @@ import (
 
 type Editor struct {
 	hswindow.Window
-	Path *hscommon.PathEntry
+	Path    *hscommon.PathEntry
+	focuser hscommon.EditorFocuser
 
 	ToFront bool
+	Focused bool
+}
+
+func (e *Editor) Control(focuser hscommon.EditorFocuser) {
+	e.focuser = focuser
 }
 
 func (e *Editor) IsVisible() bool {
 	return e.Visible
+}
+
+func (e *Editor) IsFocused() bool {
+	return e.Focused
 }
 
 func (e *Editor) GetId() string {

--- a/hswindow/hseditor/hscofeditor/cof_editor.go
+++ b/hswindow/hseditor/hscofeditor/cof_editor.go
@@ -3,7 +3,6 @@ package hscofeditor
 import (
 	g "github.com/AllenDang/giu"
 	"github.com/AllenDang/giu/imgui"
-
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hswidget"
 
@@ -44,5 +43,24 @@ func (e *COFEditor) Render() {
 
 	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Layout(g.Layout{
 		hswidget.COFViewer(e.Path.GetUniqueId(), e.cof),
+		g.Custom(func() {
+			e.Focused = imgui.IsWindowFocused(0)
+		}),
 	})
+}
+
+func (e *COFEditor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("COF Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
+	})
+
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hsdc6editor/dc6_editor.go
+++ b/hswindow/hseditor/hsdc6editor/dc6_editor.go
@@ -44,6 +44,24 @@ func (e *DC6Editor) Render() {
 
 	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Layout(g.Layout{
 		hswidget.DC6Viewer(e.Path.GetUniqueId(), e.dc6),
+		g.Custom(func() {
+			e.Focused = imgui.IsWindowFocused(0)
+		}),
+	})
+}
+
+func (e *DC6Editor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("DC6 Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
 	})
 
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hsdcceditor/dcc_editor.go
+++ b/hswindow/hseditor/hsdcceditor/dcc_editor.go
@@ -44,6 +44,24 @@ func (e *DCCEditor) Render() {
 
 	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Layout(g.Layout{
 		hswidget.DCCViewer(e.Path.GetUniqueId(), e.dcc),
+		g.Custom(func() {
+			e.Focused = imgui.IsWindowFocused(0)
+		}),
+	})
+}
+
+func (e *DCCEditor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("DCC Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
 	})
 
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hsds1editor/ds1_editor.go
+++ b/hswindow/hseditor/hsds1editor/ds1_editor.go
@@ -11,6 +11,8 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
+var _ hscommon.EditorWindow = &DS1Editor{}
+
 func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
 	ds1, err := d2ds1.LoadDS1(*data)
 	if err != nil {
@@ -45,5 +47,26 @@ func (e *DS1Editor) Render() {
 		IsOpen(&e.Visible).
 		Flags(g.WindowFlagsAlwaysAutoResize).
 		Pos(360, 30).
-		Layout(g.Layout{hswidget.DS1Viewer(e.Path.GetUniqueId(), e.ds1)})
+		Layout(g.Layout{
+			hswidget.DS1Viewer(e.Path.GetUniqueId(), e.ds1),
+			g.Custom(func() {
+				e.Focused = imgui.IsWindowFocused(0)
+			}),
+		})
+}
+
+func (e *DS1Editor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("DS1 Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
+	})
+
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -46,5 +46,26 @@ func (e *DT1Editor) Render() {
 		IsOpen(&e.Visible).
 		Flags(g.WindowFlagsAlwaysAutoResize).
 		Pos(360, 30).
-		Layout(g.Layout{hswidget.DT1Viewer(e.Path.GetUniqueId(), e.dt1)})
+		Layout(g.Layout{
+			hswidget.DT1Viewer(e.Path.GetUniqueId(), e.dt1),
+			g.Custom(func() {
+				e.Focused = imgui.IsWindowFocused(0)
+			}),
+		})
+}
+
+func (e *DT1Editor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("DT1 Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
+	})
+
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hsfonteditor/fonteditor.go
+++ b/hswindow/hseditor/hsfonteditor/fonteditor.go
@@ -30,5 +30,25 @@ func (e *FontEditor) Render() {
 		imgui.SetNextWindowFocus()
 	}
 
-	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Pos(50, 50).Size(400, 300).Layout(g.Layout{})
+	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Pos(50, 50).Size(400, 300).Layout(g.Layout{
+		g.Custom(func() {
+			e.Focused = imgui.IsWindowFocused(0)
+		}),
+	})
+}
+
+func (e *FontEditor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("Font Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
+	})
+
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
+++ b/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
@@ -96,13 +96,14 @@ func (e *FontTableEditor) Render() {
 		imgui.SetNextWindowFocus()
 	}
 
-	tableLayout := g.Layout{g.Child("").
-		Border(false).
-		Layout(
-			g.Layout{
-				g.FastTable("").Border(true).Rows(e.rows),
-			},
-		)}
+	tableLayout := g.Layout{
+		g.Child("").Border(false).Layout(g.Layout{
+			g.FastTable("").Border(true).Rows(e.rows),
+		}),
+		g.Custom(func() {
+			e.Focused = imgui.IsWindowFocused(0)
+		}),
+	}
 
 	g.Window(e.GetWindowTitle()).
 		IsOpen(&e.Visible).
@@ -124,4 +125,20 @@ func (e *FontTableEditor) makeGlyphLayout(glyph *fontGlyph) *g.RowWidget {
 	)
 
 	return row
+}
+
+func (e *FontTableEditor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("Font Table Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
+	})
+
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hspaletteeditor/palette_editor.go
+++ b/hswindow/hseditor/hspaletteeditor/palette_editor.go
@@ -45,5 +45,24 @@ func (e *PaletteEditor) Render() {
 
 	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Pos(360, 30).Layout(g.Layout{
 		hswidget.PaletteGrid(e.GetId()+"_grid", e.palette.GetColors()),
+		g.Custom(func() {
+			e.Focused = imgui.IsWindowFocused(0)
+		}),
 	})
+}
+
+func (e *PaletteEditor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("Palette Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
+	})
+
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hspalettemapeditor/palette_map_editor.go
+++ b/hswindow/hseditor/hspalettemapeditor/palette_map_editor.go
@@ -43,5 +43,24 @@ func (e *PaletteMapEditor) Render() {
 
 	g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Layout(g.Layout{
 		hswidget.PaletteMapViewer(e.Path.GetUniqueId(), e.pl2),
+		g.Custom(func() {
+			e.Focused = imgui.IsWindowFocused(0)
+		}),
 	})
+}
+
+func (e *PaletteMapEditor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("Palette Map Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
+	})
+
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hssoundeditor/soundeditor.go
+++ b/hswindow/hseditor/hssoundeditor/soundeditor.go
@@ -74,6 +74,9 @@ func (s *SoundEditor) Render() {
 			g.Button("Play").OnClick(s.play),
 			g.Button("Stop").OnClick(s.stop),
 		),
+		g.Custom(func() {
+			s.Focused = imgui.IsWindowFocused(0)
+		}),
 	})
 }
 
@@ -101,4 +104,20 @@ func (s *SoundEditor) stop() {
 	}
 	s.control.Paused = true
 	speaker.Unlock()
+}
+
+func (e *SoundEditor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("Sound Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
+	})
+
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
+++ b/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
@@ -72,14 +72,12 @@ func (e *StringTableEditor) Render() {
 	}
 
 	l := g.Layout{
-		g.Child("").
-			Border(false).
-			//Size(float32(160), 0).
-			Layout(
-				g.Layout{
-					g.FastTable("").Border(true).Rows(e.rows),
-				},
-			),
+		g.Child("").Border(false).Layout(g.Layout{
+			g.FastTable("").Border(true).Rows(e.rows),
+		}),
+		g.Custom(func() {
+			e.Focused = imgui.IsWindowFocused(0)
+		}),
 	}
 
 	g.Window(e.GetWindowTitle()).
@@ -88,4 +86,20 @@ func (e *StringTableEditor) Render() {
 		Pos(50, 50).
 		Size(400, 300).
 		Layout(l)
+}
+
+func (e *StringTableEditor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("String Table Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
+	})
+
+	*l = append(*l, m)
 }

--- a/hswindow/hseditor/hstexteditor/texteditor.go
+++ b/hswindow/hseditor/hstexteditor/texteditor.go
@@ -70,6 +70,9 @@ func (e *TextEditor) Render() {
 	if !e.tableView {
 		g.Window(e.GetWindowTitle()).IsOpen(&e.Visible).Pos(50, 50).Size(400, 300).Layout(g.Layout{
 			g.InputTextMultiline("", &e.text).Size(-1, -1).Flags(g.InputTextFlagsAllowTabInput),
+			g.Custom(func() {
+				e.Focused = imgui.IsWindowFocused(0)
+			}),
 		})
 		return
 	}
@@ -78,5 +81,24 @@ func (e *TextEditor) Render() {
 		g.Child("").Border(false).Size(float32(e.columns*80), 0).Layout(g.Layout{
 			g.FastTable("").Border(true).Rows(e.tableRows),
 		}),
+		g.Custom(func() {
+			e.Focused = imgui.IsWindowFocused(0)
+		}),
 	})
+}
+
+func (e *TextEditor) UpdateMainMenuLayout(l *g.Layout) {
+	m := g.Menu("Text Editor").Layout(g.Layout{
+		g.MenuItem("Add to project").OnClick(func() {}),
+		g.MenuItem("Remove from project").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Import from file...").OnClick(func() {}),
+		g.MenuItem("Export to file...").OnClick(func() {}),
+		g.Separator(),
+		g.MenuItem("Close").OnClick(func() {
+			e.Visible = false
+		}),
+	})
+
+	*l = append(*l, m)
 }

--- a/hswindow/window.go
+++ b/hswindow/window.go
@@ -1,6 +1,9 @@
 package hswindow
 
+import "github.com/AllenDang/giu"
+
 type Window struct {
+	Widget  *giu.WindowWidget
 	Visible bool
 }
 


### PR DESCRIPTION
* Each editor now implements the `MainMenuUpdater` interface. This interface provides a method for updating (in our case, appending to...) the layout of the main menu bar of the app.

* The app now keeps track of the currently focused editor window. This is honestly jank af, we probably don't want to be responsible for this.

* The currently-focused editor will update the main menu bar with its own editor menu. All of the entries in this context-sensitive editor menu are bogus and don't do anything, we need to address this in other PR's