### PR TITLE
Save/restore window states

### DIFF
--- a/hsapp/app_state.go
+++ b/hsapp/app_state.go
@@ -1,0 +1,58 @@
+package hsapp
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
+)
+
+func (a *App) State() hsstate.AppState {
+	appState := hsstate.AppState{
+		ProjectPath:   a.project.GetProjectFilePath(),
+		EditorWindows: []hsstate.EditorState{},
+		ToolWindows:   []hsstate.ToolWindowState{},
+	}
+
+	for _, editor := range a.editors {
+		appState.EditorWindows = append(appState.EditorWindows, editor.State())
+	}
+
+	appState.ToolWindows = append(appState.ToolWindows, a.mpqExplorer.State(), a.projectExplorer.State())
+
+	return appState
+}
+
+func (a *App) RestoreAppState(state hsstate.AppState) {
+	for _, toolState := range state.ToolWindows {
+		var tool hscommon.ToolWindow
+		switch toolState.Type {
+		case hsstate.ToolWindowTypeConsole:
+			tool = a.console
+		case hsstate.ToolWindowTypeMPQExplorer:
+			tool = a.mpqExplorer
+		case hsstate.ToolWindowTypeProjectExplorer:
+			tool = a.projectExplorer
+		default:
+			continue
+		}
+
+		tool.Pos(toolState.PosX, toolState.PosY)
+		tool.SetVisible(toolState.Visible)
+	}
+
+	for _, editorState := range state.EditorWindows {
+		editorState := editorState
+
+		var path hscommon.PathEntry
+
+		err := json.Unmarshal(editorState.Path, &path)
+		if err != nil {
+			log.Print("failed to restore editor: ", err)
+			continue
+		}
+
+		go a.createEditor(&path, editorState.PosX, editorState.PosY)
+	}
+}

--- a/hsapp/menubar.go
+++ b/hsapp/menubar.go
@@ -28,6 +28,7 @@ func (a *App) renderMainMenuBar() {
 			g.Menu("Open##MainMenuFileOpen").Layout(g.Layout{
 				g.MenuItem("Project...\t\tCtrl+O##MainMenuFileOpenProject").OnClick(a.onOpenProjectClicked),
 			}),
+			g.MenuItem("Save\t\t\t\t\t\tCtrl+S##MainMenuFileSaveProject").OnClick(a.Save),
 			g.Menu("Open Recent##MainMenuOpenRecent").Layout(g.Layout{
 				g.Custom(func() {
 					if len(a.config.RecentProjects) == 0 {

--- a/hsapp/menubar.go
+++ b/hsapp/menubar.go
@@ -45,7 +45,7 @@ func (a *App) renderMainMenuBar() {
 			g.Separator(),
 			g.MenuItem("Preferences...\t\tAlt+P##MainMenuFilePreferences").OnClick(a.onFilePreferencesClicked),
 			g.Separator(),
-			g.MenuItem("Exit\t\t\t\t\t\t  Alt+Q##MainMenuFileExit").OnClick(a.quit),
+			g.MenuItem("Exit\t\t\t\t\t\t  Alt+Q##MainMenuFileExit").OnClick(a.Quit),
 		}),
 		g.Menu("View##MainMenuView").Layout(a.buildViewMenu()),
 		g.Menu("Project##MainMenuProject").Layout(g.Layout{

--- a/hsapp/setup.go
+++ b/hsapp/setup.go
@@ -48,15 +48,15 @@ func (a *App) setup() error {
 	a.editorConstructors[hsfiletypes.FileTypeDS1] = hsds1editor.Create
 
 	// Register the tool windows
-	if a.mpqExplorer, err = hsmpqexplorer.Create(a.openEditor, a.config); err != nil {
+	if a.mpqExplorer, err = hsmpqexplorer.Create(a.openEditor, a.config, mpqExplorerDefaultX, mpqExplorerDefaultY); err != nil {
 		return err
 	}
 
-	if a.projectExplorer, err = hsprojectexplorer.Create(a.openEditor); err != nil {
+	if a.projectExplorer, err = hsprojectexplorer.Create(a.openEditor, projectExplorerDefaultX, projectExplorerDefaultY); err != nil {
 		return err
 	}
 
-	a.console = hsconsole.Create(a.fontFixed)
+	a.console = hsconsole.Create(a.fontFixed, consoleDefaultX, consoleDefaultY)
 
 	// Register the dialogs
 	if a.aboutDialog, err = hsaboutdialog.Create(a.diabloRegularFont, a.diabloBoldFont, a.fontFixedSmall); err != nil {
@@ -76,7 +76,7 @@ func (a *App) registerGlobalKeyboardShortcuts() {
 	hsinput.RegisterShortcut(a.onNewProjectClicked, g.KeyN, g.ModControl+g.ModShift, true)
 	hsinput.RegisterShortcut(a.onOpenProjectClicked, g.KeyO, g.ModControl, true)
 	hsinput.RegisterShortcut(a.onFilePreferencesClicked, g.KeyP, g.ModAlt, true)
-	hsinput.RegisterShortcut(a.quit, g.KeyQ, g.ModAlt, true)
+	hsinput.RegisterShortcut(a.Quit, g.KeyQ, g.ModAlt, true)
 	hsinput.RegisterShortcut(a.onHelpAboutClicked, g.KeyF1, g.ModNone, true)
 
 	hsinput.RegisterShortcut(a.closeActiveEditor, g.KeyW, g.ModControl, true)

--- a/hsapp/setup.go
+++ b/hsapp/setup.go
@@ -75,6 +75,7 @@ func (a *App) setup() error {
 func (a *App) registerGlobalKeyboardShortcuts() {
 	hsinput.RegisterShortcut(a.onNewProjectClicked, g.KeyN, g.ModControl+g.ModShift, true)
 	hsinput.RegisterShortcut(a.onOpenProjectClicked, g.KeyO, g.ModControl, true)
+	hsinput.RegisterShortcut(a.Save, g.KeyS, g.ModControl, true)
 	hsinput.RegisterShortcut(a.onFilePreferencesClicked, g.KeyP, g.ModAlt, true)
 	hsinput.RegisterShortcut(a.Quit, g.KeyQ, g.ModAlt, true)
 	hsinput.RegisterShortcut(a.onHelpAboutClicked, g.KeyF1, g.ModNone, true)

--- a/hscommon/editorwindow.go
+++ b/hscommon/editorwindow.go
@@ -1,5 +1,7 @@
 package hscommon
 
+import "github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
+
 type EditorWindow interface {
 	Renderable
 	MainMenuUpdater
@@ -7,6 +9,8 @@ type EditorWindow interface {
 	GetWindowTitle() string
 	Show()
 	IsVisible() bool
+	SetVisible(bool)
 	GetId() string
 	BringToFront()
+	State() hsstate.EditorState
 }

--- a/hscommon/hsstate/app_state.go
+++ b/hscommon/hsstate/app_state.go
@@ -1,0 +1,11 @@
+// Package hsstate contains structs that describe the state of the application.
+// This allows us to save the state of the application to a file when exited,
+// and then re-load the state when the application is opened again.
+package hsstate
+
+// AppState holds information related to the running state of HellSpawner.
+type AppState struct {
+	ProjectPath   string            `json:"project_path"`
+	EditorWindows []EditorState     `json:"editor_windows"`
+	ToolWindows   []ToolWindowState `json:"tool_windows"`
+}

--- a/hscommon/hsstate/editor_state.go
+++ b/hscommon/hsstate/editor_state.go
@@ -1,0 +1,7 @@
+package hsstate
+
+// EditorState holds information about all of the open editors.
+type EditorState struct {
+	WindowState
+	Path []byte `json:"path"` // this gets exported as raw JSON to prevent an import loop
+}

--- a/hscommon/hsstate/tool_window_state.go
+++ b/hscommon/hsstate/tool_window_state.go
@@ -1,0 +1,15 @@
+package hsstate
+
+type ToolWindowType string
+
+const (
+	ToolWindowTypeMPQExplorer     = ToolWindowType("MPQ Explorer")
+	ToolWindowTypeProjectExplorer = ToolWindowType("Project Explorer")
+	ToolWindowTypeConsole         = ToolWindowType("Console")
+)
+
+// ToolWindowState holds information about tool windows (e.g. MPQ Explorer)
+type ToolWindowState struct {
+	Type ToolWindowType `json:"type"`
+	WindowState
+}

--- a/hscommon/hsstate/window_state.go
+++ b/hscommon/hsstate/window_state.go
@@ -1,0 +1,8 @@
+package hsstate
+
+// WindowState holds information about windows.
+type WindowState struct {
+	Visible bool    `json:"visible"`
+	PosX    float32 `json:"x"`
+	PosY    float32 `json:"y"`
+}

--- a/hscommon/pathentry.go
+++ b/hscommon/pathentry.go
@@ -20,32 +20,32 @@ const (
 // PathEntry defines a file/folder
 type PathEntry struct {
 	// Children represents child files/folders inside a folder.
-	Children []*PathEntry
+	Children []*PathEntry `json:"children"`
 
 	// Name is the visible name of the path entry.
-	Name string
+	Name string `json:"name"`
 
 	// FullPath is the actual path of the entry (filesystem, or mpq relative).
-	FullPath string
+	FullPath string `json:"full_path"`
 
 	// IsDirectory is true when this path represents a directory.
-	IsDirectory bool
+	IsDirectory bool `json:"is_directory"`
 
 	// IsRoot is true When this path represents the root path (the project node).
-	IsRoot bool
+	IsRoot bool `json:"is_root"`
 
 	// IsRenaming is true when this path is currently being renamed in a tree view.
-	IsRenaming bool
+	IsRenaming bool `json:"is_renaming"`
 
 	// OldName is the value of the path's Name before renaming started.
 	// If renaming has not started, this value should be blank.
-	OldName string
+	OldName string `json:"old_name"`
 
 	// PathEntrySource is the type of path entry this is (MPQ or Filesystem).
-	Source PathEntrySource
+	Source PathEntrySource `json:"source"`
 
 	// MPQFile represents the full path to the MPQ that contains this file (if this is an MPQ path).
-	MPQFile string
+	MPQFile string `json:"mpq_file"`
 }
 
 func (p *PathEntry) GetUniqueId() string {

--- a/hscommon/toolwindow.go
+++ b/hscommon/toolwindow.go
@@ -1,0 +1,18 @@
+package hscommon
+
+import (
+	"github.com/ianling/giu"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
+)
+
+type ToolWindow interface {
+	Renderable
+
+	Show()
+	IsVisible() bool
+	SetVisible(bool)
+	BringToFront()
+	State() hsstate.ToolWindowState
+	Pos(x, y float32) *giu.WindowWidget
+}

--- a/hsconfig/config.go
+++ b/hsconfig/config.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
+
 	"github.com/kirsle/configdir"
 )
 
@@ -17,6 +19,7 @@ type Config struct {
 	AuxiliaryMpqPath        string
 	ExternalListFile        string
 	OpenMostRecentOnStartup bool
+	ProjectStates           map[string]hsstate.AppState
 }
 
 func getConfigPath() string {
@@ -31,6 +34,7 @@ func generateDefaultConfig() *Config {
 	result := &Config{
 		RecentProjects:          []string{},
 		OpenMostRecentOnStartup: true,
+		ProjectStates:           make(map[string]hsstate.AppState),
 	}
 
 	err := result.Save()
@@ -54,7 +58,7 @@ func Load() *Config {
 		return generateDefaultConfig()
 	}
 
-	var result *Config
+	result := generateDefaultConfig()
 	if err = json.Unmarshal(data, &result); err != nil {
 		return generateDefaultConfig()
 	}

--- a/hswindow/hseditor/editor.go
+++ b/hswindow/hseditor/editor.go
@@ -10,9 +10,9 @@ type Editor struct {
 	Path *hscommon.PathEntry
 }
 
-func New(path *hscommon.PathEntry) *Editor {
+func New(path *hscommon.PathEntry, x, y float32) *Editor {
 	return &Editor{
-		Window: hswindow.New(generateWindowTitle(path)),
+		Window: hswindow.New(generateWindowTitle(path), x, y),
 		Path:   path,
 	}
 }

--- a/hswindow/hseditor/editor.go
+++ b/hswindow/hseditor/editor.go
@@ -1,7 +1,11 @@
 package hseditor
 
 import (
+	"encoding/json"
+	"log"
+
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
 	"github.com/OpenDiablo2/HellSpawner/hswindow"
 )
 
@@ -14,6 +18,18 @@ func New(path *hscommon.PathEntry, x, y float32) *Editor {
 	return &Editor{
 		Window: hswindow.New(generateWindowTitle(path), x, y),
 		Path:   path,
+	}
+}
+
+func (e *Editor) State() hsstate.EditorState {
+	path, err := json.Marshal(e.Path)
+	if err != nil {
+		log.Print("failed to marshal editor path to JSON: ", err)
+	}
+
+	return hsstate.EditorState{
+		WindowState: e.Window.State(),
+		Path:        path,
 	}
 }
 

--- a/hswindow/hseditor/hscofeditor/cof_editor.go
+++ b/hswindow/hseditor/hscofeditor/cof_editor.go
@@ -10,14 +10,14 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	cof, err := d2cof.Load(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &COFEditor{
-		Editor: hseditor.New(pathEntry),
+		Editor: hseditor.New(pathEntry, x, y),
 		cof:    cof,
 	}
 

--- a/hswindow/hseditor/hsdc6editor/dc6_editor.go
+++ b/hswindow/hseditor/hsdc6editor/dc6_editor.go
@@ -11,14 +11,14 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	dc6, err := d2dc6.Load(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &DC6Editor{
-		Editor: hseditor.New(pathEntry),
+		Editor: hseditor.New(pathEntry, x, y),
 		dc6:    dc6,
 	}
 

--- a/hswindow/hseditor/hsdcceditor/dcc_editor.go
+++ b/hswindow/hseditor/hsdcceditor/dcc_editor.go
@@ -10,14 +10,14 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	dcc, err := d2dcc.Load(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &DCCEditor{
-		Editor: hseditor.New(pathEntry),
+		Editor: hseditor.New(pathEntry, x, y),
 		dcc:    dcc,
 	}
 

--- a/hswindow/hseditor/hsds1editor/ds1_editor.go
+++ b/hswindow/hseditor/hsds1editor/ds1_editor.go
@@ -36,7 +36,6 @@ type DS1Editor struct {
 func (e *DS1Editor) Build() {
 	e.IsOpen(&e.Visible).
 		Flags(g.WindowFlagsAlwaysAutoResize).
-		Pos(360, 30).
 		Layout(g.Layout{
 			hswidget.DS1Viewer(e.Path.GetUniqueId(), e.ds1),
 		})

--- a/hswindow/hseditor/hsds1editor/ds1_editor.go
+++ b/hswindow/hseditor/hsds1editor/ds1_editor.go
@@ -12,14 +12,14 @@ import (
 
 var _ hscommon.EditorWindow = &DS1Editor{}
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	ds1, err := d2ds1.LoadDS1(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &DS1Editor{
-		Editor: hseditor.New(pathEntry),
+		Editor: hseditor.New(pathEntry, x, y),
 		ds1:    ds1,
 	}
 

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -10,14 +10,14 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	dt1, err := d2dt1.LoadDT1(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &DT1Editor{
-		Editor:    hseditor.New(pathEntry),
+		Editor:    hseditor.New(pathEntry, x, y),
 		dt1:       dt1,
 		dt1Viewer: hswidget.DT1Viewer(pathEntry.GetUniqueId(), dt1),
 	}
@@ -35,7 +35,6 @@ type DT1Editor struct {
 func (e *DT1Editor) Build() {
 	e.IsOpen(&e.Visible).
 		Flags(g.WindowFlagsAlwaysAutoResize).
-		Pos(360, 30).
 		Layout(g.Layout{
 			hswidget.DT1Viewer(e.Path.GetUniqueId(), e.dt1),
 		})

--- a/hswindow/hseditor/hsfonteditor/fonteditor.go
+++ b/hswindow/hseditor/hsfonteditor/fonteditor.go
@@ -11,9 +11,9 @@ type FontEditor struct {
 	*hseditor.Editor
 }
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	result := &FontEditor{
-		Editor: hseditor.New(pathEntry),
+		Editor: hseditor.New(pathEntry, x, y),
 	}
 
 	return result, nil

--- a/hswindow/hseditor/hsfonteditor/fonteditor.go
+++ b/hswindow/hseditor/hsfonteditor/fonteditor.go
@@ -20,7 +20,7 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon
 }
 
 func (e *FontEditor) Build() {
-	e.IsOpen(&e.Visible).Pos(50, 50).Size(400, 300).Layout(g.Layout{})
+	e.IsOpen(&e.Visible).Size(400, 300).Layout(g.Layout{})
 }
 
 func (e *FontEditor) UpdateMainMenuLayout(l *g.Layout) {

--- a/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
+++ b/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
@@ -25,7 +25,7 @@ type fontGlyph struct {
 	width      int
 }
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	glyphs := make(fontTable)
 
 	table := *data
@@ -46,7 +46,7 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow,
 	}
 
 	editor := &FontTableEditor{
-		Editor:    hseditor.New(pathEntry),
+		Editor:    hseditor.New(pathEntry, x, y),
 		fontTable: glyphs,
 	}
 

--- a/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
+++ b/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
@@ -96,7 +96,6 @@ func (e *FontTableEditor) Build() {
 
 	e.IsOpen(&e.Visible).
 		Flags(g.WindowFlagsHorizontalScrollbar).
-		Pos(50, 50).
 		Size(400, 300).
 		Layout(tableLayout)
 }

--- a/hswindow/hseditor/hspaletteeditor/palette_editor.go
+++ b/hswindow/hseditor/hspaletteeditor/palette_editor.go
@@ -16,14 +16,14 @@ type PaletteEditor struct {
 	palette d2interface.Palette
 }
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	palette, err := d2dat.Load(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &PaletteEditor{
-		Editor:  hseditor.New(pathEntry),
+		Editor:  hseditor.New(pathEntry, x, y),
 		palette: palette,
 	}
 

--- a/hswindow/hseditor/hspaletteeditor/palette_editor.go
+++ b/hswindow/hseditor/hspaletteeditor/palette_editor.go
@@ -31,7 +31,7 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon
 }
 
 func (e *PaletteEditor) Build() {
-	e.IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Pos(360, 30).Layout(g.Layout{
+	e.IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Layout(g.Layout{
 		hswidget.PaletteGrid(e.GetId()+"_grid", e.palette.GetColors()),
 	})
 }

--- a/hswindow/hseditor/hspalettemapeditor/palette_map_editor.go
+++ b/hswindow/hseditor/hspalettemapeditor/palette_map_editor.go
@@ -10,14 +10,14 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	pl2, err := d2pl2.Load(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &PaletteMapEditor{
-		Editor: hseditor.New(pathEntry),
+		Editor: hseditor.New(pathEntry, x, y),
 		pl2:    pl2,
 	}
 

--- a/hswindow/hseditor/hssoundeditor/soundeditor.go
+++ b/hswindow/hseditor/hssoundeditor/soundeditor.go
@@ -26,7 +26,7 @@ type SoundEditor struct {
 	file     string
 }
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	streamer, format, err := wav.Decode(bytes.NewReader(*data))
 
 	if err != nil {
@@ -39,7 +39,7 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow,
 	}
 
 	result := &SoundEditor{
-		Editor:   hseditor.New(pathEntry),
+		Editor:   hseditor.New(pathEntry, x, y),
 		file:     filepath.Base(pathEntry.FullPath),
 		streamer: streamer,
 		control:  control,

--- a/hswindow/hseditor/hssoundeditor/soundeditor.go
+++ b/hswindow/hseditor/hssoundeditor/soundeditor.go
@@ -57,7 +57,7 @@ func (s *SoundEditor) Build() {
 	secondsCurrent := s.streamer.Position() / 22050
 	secondsTotal := s.streamer.Len() / 22050
 
-	s.IsOpen(&s.Visible).Flags(g.WindowFlagsNoResize).Pos(50, 50).Size(300, 100).Layout(g.Layout{
+	s.IsOpen(&s.Visible).Flags(g.WindowFlagsNoResize).Size(300, 100).Layout(g.Layout{
 		g.ProgressBar(float32(s.streamer.Position())/float32(s.streamer.Len())).Size(-1, 24).
 			Overlay(fmt.Sprintf("%d:%02d / %d:%02d", secondsCurrent/60, secondsCurrent%60, secondsTotal/60, secondsTotal%60)),
 		g.Separator(),

--- a/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
+++ b/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
@@ -70,7 +70,6 @@ func (e *StringTableEditor) Build() {
 
 	e.IsOpen(&e.Visible).
 		Flags(g.WindowFlagsHorizontalScrollbar).
-		Pos(50, 50).
 		Size(400, 300).
 		Layout(l)
 }

--- a/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
+++ b/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
@@ -18,14 +18,14 @@ type StringTableEditor struct {
 	dict   d2tbl.TextDictionary
 }
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	dict, err := d2tbl.LoadTextDictionary(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &StringTableEditor{
-		Editor: hseditor.New(pathEntry),
+		Editor: hseditor.New(pathEntry, x, y),
 		dict:   dict,
 	}
 

--- a/hswindow/hseditor/hstexteditor/texteditor.go
+++ b/hswindow/hseditor/hstexteditor/texteditor.go
@@ -19,9 +19,9 @@ type TextEditor struct {
 	columns   int
 }
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
 	result := &TextEditor{
-		Editor: hseditor.New(pathEntry),
+		Editor: hseditor.New(pathEntry, x, y),
 		text:   string(*data),
 	}
 

--- a/hswindow/hseditor/hstexteditor/texteditor.go
+++ b/hswindow/hseditor/hstexteditor/texteditor.go
@@ -59,7 +59,7 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon
 
 func (e *TextEditor) Build() {
 	if !e.tableView {
-		e.IsOpen(&e.Visible).Pos(50, 50).Size(400, 300).Layout(g.Layout{
+		e.IsOpen(&e.Visible).Size(400, 300).Layout(g.Layout{
 			g.InputTextMultiline("", &e.text).Size(-1, -1).Flags(g.InputTextFlagsAllowTabInput),
 		})
 	} else {

--- a/hswindow/hstoolwindow/hsconsole/console.go
+++ b/hswindow/hstoolwindow/hsconsole/console.go
@@ -1,9 +1,11 @@
 package hsconsole
 
 import (
-	"github.com/OpenDiablo2/HellSpawner/hswindow/hstoolwindow"
 	g "github.com/ianling/giu"
 	"github.com/ianling/imgui-go"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
+	"github.com/OpenDiablo2/HellSpawner/hswindow/hstoolwindow"
 )
 
 type Console struct {
@@ -21,7 +23,7 @@ func (c *Console) Write(p []byte) (n int, err error) {
 func Create(fontFixed imgui.Font, x, y float32) *Console {
 	result := &Console{
 		fontFixed:  fontFixed,
-		ToolWindow: hstoolwindow.New("Console", x, y),
+		ToolWindow: hstoolwindow.New("Console", hsstate.ToolWindowTypeConsole, x, y),
 	}
 
 	return result
@@ -29,7 +31,6 @@ func Create(fontFixed imgui.Font, x, y float32) *Console {
 
 func (c *Console) Build() {
 	c.IsOpen(&c.Visible).
-		Pos(10, 500).
 		Size(600, 200).
 		Layout(g.Layout{
 			g.Custom(func() {

--- a/hswindow/hstoolwindow/hsconsole/console.go
+++ b/hswindow/hstoolwindow/hsconsole/console.go
@@ -18,10 +18,10 @@ func (c *Console) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func Create(fontFixed imgui.Font) *Console {
+func Create(fontFixed imgui.Font, x, y float32) *Console {
 	result := &Console{
 		fontFixed:  fontFixed,
-		ToolWindow: hstoolwindow.New("Console"),
+		ToolWindow: hstoolwindow.New("Console", x, y),
 	}
 
 	return result

--- a/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
+++ b/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
+
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2mpq"
 	g "github.com/ianling/giu"
 
@@ -26,7 +28,7 @@ type MPQExplorer struct {
 
 func Create(fileSelectedCallback MPQExplorerFileSelectedCallback, config *hsconfig.Config, x, y float32) (*MPQExplorer, error) {
 	result := &MPQExplorer{
-		ToolWindow:           hstoolwindow.New("MPQ Explorer", x, y),
+		ToolWindow:           hstoolwindow.New("MPQ Explorer", hsstate.ToolWindowTypeMPQExplorer, x, y),
 		fileSelectedCallback: fileSelectedCallback,
 		config:               config,
 	}
@@ -40,7 +42,6 @@ func (m *MPQExplorer) SetProject(project *hsproject.Project) {
 
 func (m *MPQExplorer) Build() {
 	m.IsOpen(&m.Visible).
-		Pos(10, 30).
 		Size(300, 400).
 		Layout(g.Layout{
 			g.Child("MpqExplorerContent").

--- a/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
+++ b/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
@@ -24,9 +24,9 @@ type MPQExplorer struct {
 	nodeCache            []g.Widget
 }
 
-func Create(fileSelectedCallback MPQExplorerFileSelectedCallback, config *hsconfig.Config) (*MPQExplorer, error) {
+func Create(fileSelectedCallback MPQExplorerFileSelectedCallback, config *hsconfig.Config, x, y float32) (*MPQExplorer, error) {
 	result := &MPQExplorer{
-		ToolWindow:           hstoolwindow.New("MPQ Explorer"),
+		ToolWindow:           hstoolwindow.New("MPQ Explorer", x, y),
 		fileSelectedCallback: fileSelectedCallback,
 		config:               config,
 	}

--- a/hswindow/hstoolwindow/hsprojectexplorer/projectexplorer.go
+++ b/hswindow/hstoolwindow/hsprojectexplorer/projectexplorer.go
@@ -34,9 +34,9 @@ type ProjectExplorer struct {
 	refreshIconTexture   *g.Texture
 }
 
-func Create(fileSelectedCallback ProjectExplorerFileSelectedCallback) (*ProjectExplorer, error) {
+func Create(fileSelectedCallback ProjectExplorerFileSelectedCallback, x, y float32) (*ProjectExplorer, error) {
 	result := &ProjectExplorer{
-		ToolWindow:           hstoolwindow.New("Project Explorer"),
+		ToolWindow:           hstoolwindow.New("Project Explorer", x, y),
 		nodeCache:            make(map[string][]g.Widget),
 		fileSelectedCallback: fileSelectedCallback,
 	}

--- a/hswindow/hstoolwindow/hsprojectexplorer/projectexplorer.go
+++ b/hswindow/hstoolwindow/hsprojectexplorer/projectexplorer.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
+
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsfiletypes"
 
 	"github.com/OpenDiablo2/dialog"
@@ -29,6 +31,7 @@ type ProjectExplorerFileSelectedCallback func(path *hscommon.PathEntry)
 type ProjectExplorer struct {
 	*hstoolwindow.ToolWindow
 
+	project              *hsproject.Project
 	fileSelectedCallback ProjectExplorerFileSelectedCallback
 	nodeCache            map[string][]g.Widget
 	refreshIconTexture   *g.Texture
@@ -36,7 +39,7 @@ type ProjectExplorer struct {
 
 func Create(fileSelectedCallback ProjectExplorerFileSelectedCallback, x, y float32) (*ProjectExplorer, error) {
 	result := &ProjectExplorer{
-		ToolWindow:           hstoolwindow.New("Project Explorer", x, y),
+		ToolWindow:           hstoolwindow.New("Project Explorer", hsstate.ToolWindowTypeProjectExplorer, x, y),
 		nodeCache:            make(map[string][]g.Widget),
 		fileSelectedCallback: fileSelectedCallback,
 	}
@@ -49,17 +52,24 @@ func Create(fileSelectedCallback ProjectExplorerFileSelectedCallback, x, y float
 	return result, nil
 }
 
-func (m *ProjectExplorer) Build(project *hsproject.Project) {
+func (m *ProjectExplorer) SetProject(project *hsproject.Project) {
+	m.project = project
+}
+
+func (m *ProjectExplorer) Build() {
+	if m.project == nil {
+		return
+	}
+
 	header := g.Line(
-		m.makeRefreshButtonLayout(project),
+		m.makeRefreshButtonLayout(),
 	)
 
 	tree := g.Child("ProjectExplorerProjectTreeContainer").
 		Flags(g.WindowFlagsHorizontalScrollbar).
-		Layout(m.getProjectTreeNodes(project))
+		Layout(m.getProjectTreeNodes())
 
 	m.IsOpen(&m.Visible).
-		Pos(10, 30).
 		Size(300, 400).
 		Layout(g.Layout{
 			header,
@@ -68,16 +78,16 @@ func (m *ProjectExplorer) Build(project *hsproject.Project) {
 		})
 }
 
-func (m *ProjectExplorer) makeRefreshButtonLayout(project *hsproject.Project) g.Layout {
+func (m *ProjectExplorer) makeRefreshButtonLayout() g.Layout {
 	button := g.ImageButton(m.refreshIconTexture).
 		Size(16, 16).
 		OnClick(func() {
-			m.onRefreshProjectExplorerClicked(project)
+			m.onRefreshProjectExplorerClicked()
 		})
 
 	const tooltipText = "Refresh the view from the filesystem."
 
-	if project == nil {
+	if m.project == nil {
 		button.TintColor(color.RGBA{R: 0xFF, G: 0xFF, B: 0xFF, A: 0x20})
 	}
 
@@ -101,42 +111,41 @@ func (m *ProjectExplorer) makeRefreshButtonLayout(project *hsproject.Project) g.
 	}
 }
 
-func (m *ProjectExplorer) getProjectTreeNodes(project *hsproject.Project) g.Layout {
-
-	if project == nil {
+func (m *ProjectExplorer) getProjectTreeNodes() g.Layout {
+	if m.project == nil {
 		return []g.Widget{g.Label("No project loaded...")}
 	}
 
-	fileStructure := project.GetFileStructure()
+	fileStructure := m.project.GetFileStructure()
 
 	if fileStructure == nil {
 		return []g.Widget{g.Label("No file structure detected...")}
 	}
 
-	return []g.Widget{m.renderNodes(project.GetFileStructure(), project)}
+	return []g.Widget{m.renderNodes(m.project.GetFileStructure())}
 }
 
-func (m *ProjectExplorer) onRefreshProjectExplorerClicked(project *hsproject.Project) {
-	if project == nil {
+func (m *ProjectExplorer) onRefreshProjectExplorerClicked() {
+	if m.project == nil {
 		return
 	}
 
-	project.InvalidateFileStructure()
+	m.project.InvalidateFileStructure()
 }
 
-func (m *ProjectExplorer) onNewFontClicked(pathEntry *hscommon.PathEntry, project *hsproject.Project) {
-	project.CreateNewFile(hsfiletypes.FileTypeFont, pathEntry)
+func (m *ProjectExplorer) onNewFontClicked(pathEntry *hscommon.PathEntry) {
+	m.project.CreateNewFile(hsfiletypes.FileTypeFont, pathEntry)
 }
 
-func (m *ProjectExplorer) renderNodes(pathEntry *hscommon.PathEntry, project *hsproject.Project) g.Widget {
+func (m *ProjectExplorer) renderNodes(pathEntry *hscommon.PathEntry) g.Widget {
 
 	if !pathEntry.IsDirectory {
-		return m.createFileTreeItem(pathEntry, project)
+		return m.createFileTreeItem(pathEntry)
 	}
 
 	// File items and empty dirs
 	if len(pathEntry.Children) == 0 {
-		return m.createDirectoryTreeItem(pathEntry, nil, project)
+		return m.createDirectoryTreeItem(pathEntry, nil)
 	}
 
 	widgets := make([]g.Widget, len(pathEntry.Children))
@@ -144,13 +153,13 @@ func (m *ProjectExplorer) renderNodes(pathEntry *hscommon.PathEntry, project *hs
 	sortPaths(pathEntry)
 
 	for idx := range pathEntry.Children {
-		widgets[idx] = m.renderNodes(pathEntry.Children[idx], project)
+		widgets[idx] = m.renderNodes(pathEntry.Children[idx])
 	}
 
-	return m.createDirectoryTreeItem(pathEntry, widgets, project)
+	return m.createDirectoryTreeItem(pathEntry, widgets)
 }
 
-func (m *ProjectExplorer) createFileTreeItem(pathEntry *hscommon.PathEntry, project *hsproject.Project) g.Widget {
+func (m *ProjectExplorer) createFileTreeItem(pathEntry *hscommon.PathEntry) g.Widget {
 	id := "##ProjectExplorerNode_" + pathEntry.FullPath
 	var layout g.Layout = make([]g.Widget, 0)
 
@@ -161,7 +170,7 @@ func (m *ProjectExplorer) createFileTreeItem(pathEntry *hscommon.PathEntry, proj
 				if imgui.InputTextV("##RenameField_"+pathEntry.FullPath, &pathEntry.Name,
 					int(g.InputTextFlagsAutoSelectAll|g.InputTextFlagsEnterReturnsTrue), nil) {
 					pathEntry.IsRenaming = false
-					m.onFileRenamed(pathEntry, project)
+					m.onFileRenamed(pathEntry)
 				}
 			}),
 		}
@@ -174,14 +183,14 @@ func (m *ProjectExplorer) createFileTreeItem(pathEntry *hscommon.PathEntry, proj
 	layout = append(layout,
 		g.ContextMenu("Context"+id).Layout(g.Layout{
 			g.MenuItem("Rename").OnClick(func() { m.onRenameFileClicked(pathEntry) }),
-			g.MenuItem("Delete...").OnClick(func() { m.onDeleteFileClicked(pathEntry, project) }),
+			g.MenuItem("Delete...").OnClick(func() { m.onDeleteFileClicked(pathEntry) }),
 		}),
 	)
 
 	return layout
 }
 
-func (m *ProjectExplorer) createDirectoryTreeItem(pathEntry *hscommon.PathEntry, layout g.Layout, project *hsproject.Project) g.Widget {
+func (m *ProjectExplorer) createDirectoryTreeItem(pathEntry *hscommon.PathEntry, layout g.Layout) g.Widget {
 	var id = pathEntry.Name + "##ProjectExplorerNode_" + pathEntry.FullPath
 
 	if pathEntry.IsRenaming {
@@ -191,7 +200,7 @@ func (m *ProjectExplorer) createDirectoryTreeItem(pathEntry *hscommon.PathEntry,
 				if imgui.InputTextV("##RenameField_"+pathEntry.FullPath, &pathEntry.Name,
 					int(g.InputTextFlagsAutoSelectAll|g.InputTextFlagsEnterReturnsTrue), nil) {
 					pathEntry.IsRenaming = false
-					m.onFileRenamed(pathEntry, project)
+					m.onFileRenamed(pathEntry)
 				}
 			}),
 		}
@@ -199,8 +208,8 @@ func (m *ProjectExplorer) createDirectoryTreeItem(pathEntry *hscommon.PathEntry,
 
 	contextMenuLayout := g.Layout{
 		g.Menu("New").Layout(g.Layout{
-			g.MenuItem("Folder").OnClick(func() { m.onNewFolderClicked(pathEntry, project) }),
-			g.MenuItem("Font").OnClick(func() { m.onNewFontClicked(pathEntry, project) }),
+			g.MenuItem("Folder").OnClick(func() { m.onNewFolderClicked(pathEntry) }),
+			g.MenuItem("Font").OnClick(func() { m.onNewFontClicked(pathEntry) }),
 		}),
 	}
 
@@ -208,7 +217,7 @@ func (m *ProjectExplorer) createDirectoryTreeItem(pathEntry *hscommon.PathEntry,
 		contextMenuLayout = append(contextMenuLayout,
 			g.Separator(),
 			g.MenuItem("Rename").OnClick(func() { m.onRenameFileClicked(pathEntry) }),
-			g.MenuItem("Delete Folder...").OnClick(func() { m.onDeleteFolderClicked(pathEntry, project) }),
+			g.MenuItem("Delete Folder...").OnClick(func() { m.onDeleteFolderClicked(pathEntry) }),
 		)
 	}
 
@@ -225,7 +234,7 @@ func (m *ProjectExplorer) createDirectoryTreeItem(pathEntry *hscommon.PathEntry,
 	return g.TreeNode(id).Layout(append(menuLayout, layout...))
 }
 
-func (m *ProjectExplorer) onDeleteFolderClicked(entry *hscommon.PathEntry, project *hsproject.Project) {
+func (m *ProjectExplorer) onDeleteFolderClicked(entry *hscommon.PathEntry) {
 	if !dialog.Message("Are you sure you want to delete:\n%s", entry.FullPath).YesNo() {
 		return
 	}
@@ -235,10 +244,10 @@ func (m *ProjectExplorer) onDeleteFolderClicked(entry *hscommon.PathEntry, proje
 		return
 	}
 
-	project.InvalidateFileStructure()
+	m.project.InvalidateFileStructure()
 }
 
-func (m *ProjectExplorer) onDeleteFileClicked(entry *hscommon.PathEntry, project *hsproject.Project) {
+func (m *ProjectExplorer) onDeleteFileClicked(entry *hscommon.PathEntry) {
 	if !dialog.Message("Are you sure you want to delete:\n%s", entry.FullPath).YesNo() {
 		return
 	}
@@ -247,7 +256,7 @@ func (m *ProjectExplorer) onDeleteFileClicked(entry *hscommon.PathEntry, project
 		return
 	}
 
-	project.InvalidateFileStructure()
+	m.project.InvalidateFileStructure()
 }
 
 func (m *ProjectExplorer) onRenameFileClicked(entry *hscommon.PathEntry) {
@@ -255,7 +264,7 @@ func (m *ProjectExplorer) onRenameFileClicked(entry *hscommon.PathEntry) {
 	entry.IsRenaming = true
 }
 
-func (m *ProjectExplorer) onFileRenamed(entry *hscommon.PathEntry, project *hsproject.Project) {
+func (m *ProjectExplorer) onFileRenamed(entry *hscommon.PathEntry) {
 	if entry.Name == entry.OldName {
 		entry.OldName = ""
 		return
@@ -297,11 +306,11 @@ func (m *ProjectExplorer) onFileRenamed(entry *hscommon.PathEntry, project *hspr
 		return
 	}
 
-	project.InvalidateFileStructure()
+	m.project.InvalidateFileStructure()
 }
 
-func (m *ProjectExplorer) onNewFolderClicked(pathEntry *hscommon.PathEntry, project *hsproject.Project) {
-	project.CreateNewFolder(pathEntry)
+func (m *ProjectExplorer) onNewFolderClicked(pathEntry *hscommon.PathEntry) {
+	m.project.CreateNewFolder(pathEntry)
 }
 
 func sortPaths(rootPath *hscommon.PathEntry) {

--- a/hswindow/hstoolwindow/toolwindow.go
+++ b/hswindow/hstoolwindow/toolwindow.go
@@ -6,8 +6,8 @@ type ToolWindow struct {
 	*hswindow.Window
 }
 
-func New(title string) *ToolWindow {
+func New(title string, x, y float32) *ToolWindow {
 	return &ToolWindow{
-		Window: hswindow.New(title),
+		Window: hswindow.New(title, x, y),
 	}
 }

--- a/hswindow/hstoolwindow/toolwindow.go
+++ b/hswindow/hstoolwindow/toolwindow.go
@@ -1,13 +1,25 @@
 package hstoolwindow
 
-import "github.com/OpenDiablo2/HellSpawner/hswindow"
+import (
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
+	"github.com/OpenDiablo2/HellSpawner/hswindow"
+)
 
 type ToolWindow struct {
 	*hswindow.Window
+	Type hsstate.ToolWindowType
 }
 
-func New(title string, x, y float32) *ToolWindow {
+func New(title string, toolWindowType hsstate.ToolWindowType, x, y float32) *ToolWindow {
 	return &ToolWindow{
 		Window: hswindow.New(title, x, y),
+		Type:   toolWindowType,
+	}
+}
+
+func (t *ToolWindow) State() hsstate.ToolWindowState {
+	return hsstate.ToolWindowState{
+		WindowState: t.Window.State(),
+		Type:        t.Type,
 	}
 }

--- a/hswindow/window.go
+++ b/hswindow/window.go
@@ -7,9 +7,9 @@ type Window struct {
 	Visible bool
 }
 
-func New(title string) *Window {
+func New(title string, x, y float32) *Window {
 	return &Window{
-		WindowWidget: giu.Window(title),
+		WindowWidget: giu.Window(title).Pos(x, y),
 	}
 }
 

--- a/hswindow/window.go
+++ b/hswindow/window.go
@@ -1,6 +1,10 @@
 package hswindow
 
-import "github.com/ianling/giu"
+import (
+	"github.com/ianling/giu"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
+)
 
 type Window struct {
 	*giu.WindowWidget
@@ -13,12 +17,26 @@ func New(title string, x, y float32) *Window {
 	}
 }
 
+func (t *Window) State() hsstate.WindowState {
+	x, y := t.CurrentPosition()
+
+	return hsstate.WindowState{
+		Visible: t.Visible,
+		PosX:    x,
+		PosY:    y,
+	}
+}
+
 func (t *Window) ToggleVisibility() {
 	t.Visible = !t.Visible
 }
 
 func (t *Window) Show() {
 	t.Visible = true
+}
+
+func (t *Window) Build() {
+
 }
 
 func (t *Window) Render() {
@@ -31,6 +49,10 @@ func (t *Window) RegisterKeyboardShortcuts() {
 
 func (t *Window) IsVisible() bool {
 	return t.Visible
+}
+
+func (t *Window) SetVisible(visible bool) {
+	t.Visible = visible
 }
 
 func (t *Window) Cleanup() {


### PR DESCRIPTION
This adds a bunch of `State()` methods to things, which allows us to serialize/deserialize a bunch of our objects to JSON, like editor windows.

When you save, or close HellSpawner, the state of all the open windows gets saved to the config file. When you re-open HellSpawner, or load a new project, the state of all open windows for that project is restored.