### PR TITLE
Fix crash on first open of MPQ Explorer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20201108214237-06ea97f0c265
 	github.com/go-resty/resty/v2 v2.4.0 // indirect
 	github.com/hajimehoshi/oto v0.7.1 // indirect
-	github.com/ianling/giu v0.5.1-0.20210118001039-3474e38a32ea
+	github.com/ianling/giu v0.5.1-0.20210118214207-b29f443330f7
 	github.com/ianling/imgui-go v1.12.1-0.20210115050955-434395a2da82
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	golang.org/x/exp v0.0.0-20201229011636-eab1b5eb1a03 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/ianling/giu v0.5.1-0.20210117210417-49e09fba0b14 h1:EMiSGc6JNXFyu4yhA
 github.com/ianling/giu v0.5.1-0.20210117210417-49e09fba0b14/go.mod h1:w4SqEWOdPOzBbmPne4xUntHvNX8H1hntDwyyT5yUs9o=
 github.com/ianling/giu v0.5.1-0.20210118001039-3474e38a32ea h1:SZmz9rtEo+glc8NT50x2AepaMaH86UbYWXyo+Ha5S54=
 github.com/ianling/giu v0.5.1-0.20210118001039-3474e38a32ea/go.mod h1:w4SqEWOdPOzBbmPne4xUntHvNX8H1hntDwyyT5yUs9o=
+github.com/ianling/giu v0.5.1-0.20210118214207-b29f443330f7 h1:KsJrIgPoCRtn+98ZMlsI1v7lgh6wqgqUCI3cI5ryoac=
+github.com/ianling/giu v0.5.1-0.20210118214207-b29f443330f7/go.mod h1:w4SqEWOdPOzBbmPne4xUntHvNX8H1hntDwyyT5yUs9o=
 github.com/ianling/imgui-go v1.12.1-0.20210115050955-434395a2da82 h1:0MOR+YCbB8lqENL09KZzWMGiCCc3gnVfo4OLS1UWL4s=
 github.com/ianling/imgui-go v1.12.1-0.20210115050955-434395a2da82/go.mod h1:yFLUkH/g8eMfNx16GrLoCGUDjTjjHAQjrg5EMdspDUY=
 github.com/jakecoffman/cp v1.0.0/go.mod h1:JjY/Fp6d8E1CHnu74gWNnU0+b9VzEdUVPoJxg2PsTQg=

--- a/hsapp/app.go
+++ b/hsapp/app.go
@@ -106,7 +106,6 @@ func (a *App) Run() {
 
 	wnd.SetInputCallback(hsinput.HandleInput)
 	wnd.Run(a.render)
-
 }
 
 func (a *App) render() {
@@ -320,7 +319,7 @@ func (a *App) onProjectPropertiesChanged(project hsproject.Project) {
 }
 
 func (a *App) onPreferencesChanged(config hsconfig.Config) {
-	a.config = &config
+	*a.config = config
 	if err := a.config.Save(); err != nil {
 		log.Fatal(err)
 	}
@@ -368,7 +367,9 @@ func (a *App) CloseAllOpenWindows() {
 }
 
 func (a *App) Save() {
-	a.config.ProjectStates[a.project.GetProjectFilePath()] = a.State()
+	if a.project != nil {
+		a.config.ProjectStates[a.project.GetProjectFilePath()] = a.State()
+	}
 
 	err := a.config.Save()
 	if err != nil {
@@ -386,6 +387,5 @@ func (a *App) Quit() {
 
 	a.CloseAllOpenWindows()
 
-	p, _ := os.FindProcess(os.Getpid())
-	_ = p.Kill()
+	os.Exit(0)
 }


### PR DESCRIPTION
Fixes #136 

a.config was being set to a new pointer, instead of updating the referenced object.

also fixes a couple of nil pointer exceptions