### PR TITLE
windows: default project explorer window position changed

### DIFF
--- a/hsapp/app.go
+++ b/hsapp/app.go
@@ -39,7 +39,7 @@ const (
 	editorWindowDefaultX    = 320
 	editorWindowDefaultY    = 30
 	projectExplorerDefaultX = 0
-	projectExplorerDefaultY = 0
+	projectExplorerDefaultY = 25
 	mpqExplorerDefaultX     = 30
 	mpqExplorerDefaultY     = 30
 	consoleDefaultX         = 10


### PR DESCRIPTION
Hi there,
It was a minor bug, which caused, that on first open of project explorer, it's window covered over menubar.