### PR TITLE
empty aux mpq's list bug, and save on Add Aux MPQ

### DIFF
--- a/hswindow/hsdialog/hsprojectpropertiesdialog/projectpropertiesdialog.go
+++ b/hswindow/hsdialog/hsprojectpropertiesdialog/projectpropertiesdialog.go
@@ -80,8 +80,9 @@ func (p *ProjectPropertiesDialog) Build() {
 			g.ListBox("ProjectPropertiesSelectAuxMPQDialogItems", p.auxMPQNames).Border(false).OnChange(func(selectedIndex int) {
 				p.mpqSelectDlgIndex = selectedIndex
 			}).OnDClick(func(selectedIndex int) {
-				p.mpqSelectDialogVisible = false
 				p.addAuxMpq(p.auxMPQs[selectedIndex])
+				p.onProjectPropertiesChanged(p.project)
+				p.mpqSelectDialogVisible = false
 			}),
 		}),
 		g.Line(

--- a/hswindow/hsdialog/hsprojectpropertiesdialog/projectpropertiesdialog.go
+++ b/hswindow/hsdialog/hsprojectpropertiesdialog/projectpropertiesdialog.go
@@ -86,7 +86,12 @@ func (p *ProjectPropertiesDialog) Build() {
 		}),
 		g.Line(
 			g.Button("Add Selected...##ProjectPropertiesSelectAuxMPQDialogAddSelected").OnClick(func() {
-				p.addAuxMpq(p.auxMPQs[p.mpqSelectDlgIndex])
+				// checks if aux MPQs list isn't empty
+				if len(p.auxMPQs) > 0 {
+					p.addAuxMpq(p.auxMPQs[p.mpqSelectDlgIndex])
+					p.onProjectPropertiesChanged(p.project)
+				}
+
 				p.mpqSelectDialogVisible = false
 			}),
 			g.Button("Cancel##ProjectPropertiesSelectAuxMPQDialogCancel").OnClick(func() {


### PR DESCRIPTION
Hi there,
Two minor bugs:
- when mpqs' list is empty, HellSpawner doesn't crash
- when we click on Add Selected (in add aux mpq dialog) selection is saved