### PR TITLE
Add structure for editor saving, font editor

### DIFF
--- a/hsapp/app.go
+++ b/hsapp/app.go
@@ -60,7 +60,7 @@ type App struct {
 	console         *hsconsole.Console
 
 	editors            []hscommon.EditorWindow
-	editorConstructors map[hsfiletypes.FileType]func(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error)
+	editorConstructors map[hsfiletypes.FileType]func(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error)
 	editorManagerMutex sync.RWMutex
 	focusedEditor      hscommon.EditorWindow
 
@@ -73,7 +73,7 @@ type App struct {
 func Create() (*App, error) {
 	result := &App{
 		editors:            make([]hscommon.EditorWindow, 0),
-		editorConstructors: make(map[hsfiletypes.FileType]func(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error)),
+		editorConstructors: make(map[hsfiletypes.FileType]func(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error)),
 		config:             hsconfig.Load(),
 	}
 
@@ -91,11 +91,12 @@ func (a *App) Run() {
 		log.Fatal(err)
 	}
 
+	dialog.Init()
+
 	if a.config.OpenMostRecentOnStartup && len(a.config.RecentProjects) > 0 {
 		a.loadProjectFromFile(a.config.RecentProjects[0])
 	}
 
-	dialog.Init()
 	hscommon.ProcessTextureLoadRequests()
 
 	defer a.Quit()
@@ -210,10 +211,10 @@ func (a *App) createEditor(path *hscommon.PathEntry, x, y float32) {
 		return
 	}
 
-	editor, err := a.editorConstructors[fileType](path, &data, x, y)
+	editor, err := a.editorConstructors[fileType](path, &data, x, y, a.project)
 
 	if err != nil {
-		dialog.Message("Error creating editor!").Error()
+		dialog.Message("Error creating editor: %s", err).Error()
 		return
 	}
 
@@ -316,7 +317,8 @@ func (a *App) toggleProjectExplorer() {
 func (a *App) closeActiveEditor() {
 	for _, editor := range a.editors {
 		if editor.HasFocus() {
-			editor.Cleanup()
+			// don't call Cleanup here. the Render loop will call Cleanup when it notices that this editor isn't visible
+			editor.SetVisible(false)
 			return
 		}
 	}
@@ -350,6 +352,10 @@ func (a *App) Save() {
 	if err != nil {
 		log.Print("failed to save config: ", err)
 		return
+	}
+
+	if a.focusedEditor != nil {
+		a.focusedEditor.Save()
 	}
 }
 

--- a/hscommon/editorwindow.go
+++ b/hscommon/editorwindow.go
@@ -6,11 +6,20 @@ type EditorWindow interface {
 	Renderable
 	MainMenuUpdater
 
+	// GetWindowTitle controls what the window title for this editor appears as
 	GetWindowTitle() string
+	// Show sets Visible to true
 	Show()
+	// IsVisible returns true if the editor has not been closed
 	IsVisible() bool
+	// SetVisible can be used to set Visible to false if the editor should be closed
 	SetVisible(bool)
+	// GetId returns a unique identifier for this editor window
 	GetId() string
+	// BringToFront brings this editor to the front of the application, giving it focus
 	BringToFront()
+	// State returns the current state of this editor, in a JSON-serializable struct
 	State() hsstate.EditorState
+	// Save writes any changes made in the editor to the file that is open in the editor.
+	Save()
 }

--- a/hscommon/hsfiletypes/hsfont/font.go
+++ b/hscommon/hsfiletypes/hsfont/font.go
@@ -3,7 +3,6 @@ package hsfont
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"os"
 )
 
@@ -26,12 +25,27 @@ func NewFile(filePath string) (*Font, error) {
 	return result, nil
 }
 
+func LoadFromJSON(data []byte) (*Font, error) {
+	var font *Font = &Font{}
+
+	err := json.Unmarshal(data, font)
+
+	return font, err
+}
+
+func (f *Font) JSON() ([]byte, error) {
+	data, err := json.MarshalIndent(f, "", "   ")
+
+	return data, err
+}
+
 func (f *Font) SaveToFile() error {
 	var data []byte
 	var err error
 
-	if data, err = json.MarshalIndent(f, "", "   "); err != nil {
-		log.Fatal(err)
+	data, err = f.JSON()
+	if err != nil {
+		return err
 	}
 
 	if err = ioutil.WriteFile(f.filePath, data, os.FileMode(0644)); err != nil {

--- a/hscommon/main_menu_updater.go
+++ b/hscommon/main_menu_updater.go
@@ -3,5 +3,9 @@ package hscommon
 import "github.com/ianling/giu"
 
 type MainMenuUpdater interface {
+	// UpdateMainMenuLayout receives a pointer to the current layout of the menu bar at the top of the application,
+	// allowing a struct implementing this interface to alter the menu bar.
+	// This is generally used for adding a menu to the bar specific to the struct implementing this method, with options
+	// that would be useful for that struct.
 	UpdateMainMenuLayout(layout *giu.Layout)
 }

--- a/hscommon/pathentry.go
+++ b/hscommon/pathentry.go
@@ -3,9 +3,10 @@ package hscommon
 import (
 	"errors"
 	"fmt"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2mpq"
 	"io/ioutil"
 	"os"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2mpq"
 )
 
 // PathEntrySource represents the type of path entry.
@@ -58,6 +59,7 @@ func (p *PathEntry) GetUniqueId() string {
 	return fmt.Sprintf("%d_%s_%s", p.Source, p.MPQFile, p.FullPath)
 }
 
+// GetFileBytes reads the file and returns the contents
 func (p *PathEntry) GetFileBytes() ([]byte, error) {
 	if p.Source == PathEntrySourceProject {
 		if _, err := os.Stat(p.FullPath); os.IsNotExist(err) {
@@ -77,4 +79,23 @@ func (p *PathEntry) GetFileBytes() ([]byte, error) {
 	}
 
 	return nil, errors.New("could not locate file in mpq")
+}
+
+// WriteFile overwrites the file with the given data
+func (p *PathEntry) WriteFile(data []byte) error {
+	if p.Source != PathEntrySourceProject {
+		return errors.New("saving is only supported for files in project, cannot write to MPQs")
+	}
+
+	info, err := os.Stat(p.FullPath)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(p.FullPath, data, info.Mode())
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/hsinput/input_handler.go
+++ b/hsinput/input_handler.go
@@ -73,6 +73,8 @@ func HandleInput(key glfw.Key, mods glfw.ModifierKey, action glfw.Action) {
 			} else if callbackFuncs.Global != nil {
 				callbackFuncs.Global()
 			}
+
+			return
 		}
 	}
 }

--- a/hswindow/hsdialog/hspreferencesdialog/preferencesdialog.go
+++ b/hswindow/hsdialog/hspreferencesdialog/preferencesdialog.go
@@ -36,20 +36,20 @@ func (p *PreferencesDialog) Build() {
 		g.Child("PreferencesLayout").Size(300, 200).Layout(g.Layout{
 			g.Label("Auxiliary MPQ Path"),
 			g.Line(
+				g.InputText("##AppPreferencesAuxMPQPath", &p.config.AuxiliaryMpqPath).Size(245).Flags(g.InputTextFlagsReadOnly),
 				g.Button("...##AppPreferencesAuxMPQPathBrowse").Size(30, 0).OnClick(p.onBrowseAuxMpqPathClicked),
-				g.InputText("##AppPreferencesAuxMPQPath", &p.config.AuxiliaryMpqPath).Size(-1).Flags(g.InputTextFlagsReadOnly),
 			),
 			g.Separator(),
 			g.Label("External MPQ listfile Path"),
 			g.Line(
+				g.InputText("##AppPreferencesListfilePath", &p.config.ExternalListFile).Size(245).Flags(g.InputTextFlagsReadOnly),
 				g.Button("...##AppPreferencesListfilePathBrowse").Size(30, 0).OnClick(p.onBrowseExternalListfileClicked),
-				g.InputText("##AppPreferencesListfilePath", &p.config.ExternalListFile).Size(-1).Flags(g.InputTextFlagsReadOnly),
 			),
 			g.Separator(),
 			g.Label("Abyss Engine Path"),
 			g.Line(
+				g.InputText("##AppPreferencesAbyssEnginePath", &p.config.AbyssEnginePath).Size(245).Flags(g.InputTextFlagsReadOnly),
 				g.Button("...##AppPreferencesAbyssEnginePathBrowse").Size(30, 0).OnClick(p.onBrowseAbyssEngineClicked),
-				g.InputText("##AppPreferencesAbyssEnginePath", &p.config.AbyssEnginePath).Size(-1).Flags(g.InputTextFlagsReadOnly),
 			),
 			g.Separator(),
 			g.Checkbox("Open most recent project on start-up", &p.config.OpenMostRecentOnStartup),

--- a/hswindow/hseditor/editor.go
+++ b/hswindow/hseditor/editor.go
@@ -1,8 +1,12 @@
 package hseditor
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"log"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
@@ -11,13 +15,15 @@ import (
 
 type Editor struct {
 	*hswindow.Window
-	Path *hscommon.PathEntry
+	Path    *hscommon.PathEntry
+	Project *hsproject.Project
 }
 
-func New(path *hscommon.PathEntry, x, y float32) *Editor {
+func New(path *hscommon.PathEntry, x, y float32, project *hsproject.Project) *Editor {
 	return &Editor{
-		Window: hswindow.New(generateWindowTitle(path), x, y),
-		Path:   path,
+		Window:  hswindow.New(generateWindowTitle(path), x, y),
+		Path:    path,
+		Project: project,
 	}
 }
 
@@ -39,6 +45,63 @@ func (e *Editor) GetWindowTitle() string {
 
 func (e *Editor) GetId() string {
 	return e.Path.GetUniqueId()
+}
+
+func (e *Editor) Save(editor Saveable) {
+	if e.Path.Source != hscommon.PathEntrySourceProject {
+		// saving to MPQ not yet supported
+		return
+	}
+
+	if editor, isSaveable := editor.(Saveable); isSaveable {
+		saveData := editor.GenerateSaveData()
+		if saveData == nil {
+			return
+		}
+
+		existingFileData, err := e.Path.GetFileBytes()
+		if err != nil {
+			fmt.Println("failed to read file before saving: ", err)
+			return
+		}
+
+		if bytes.Equal(saveData, existingFileData) {
+			// nothing to save
+			return
+		}
+
+		err = e.Path.WriteFile(saveData)
+		if err != nil {
+			fmt.Println("failed to save file: ", err)
+			return
+		}
+	} else {
+		return
+	}
+}
+
+func (e *Editor) HasChanges(editor Saveable) bool {
+	if e.Path.Source != hscommon.PathEntrySourceProject {
+		// saving to MPQ not yet supported
+		return false
+	}
+
+	if editor, isSaveable := editor.(Saveable); isSaveable {
+		newData := editor.GenerateSaveData()
+		if newData != nil {
+			oldData, err := e.Path.GetFileBytes()
+			if err == nil {
+				return !bytes.Equal(oldData, newData)
+			}
+		}
+	}
+
+	// err on the side of caution; if any errors occurred, just say nothing has changed so no changes get saved
+	return false
+}
+
+func (e *Editor) Cleanup() {
+	e.Window.Cleanup()
 }
 
 func generateWindowTitle(path *hscommon.PathEntry) string {

--- a/hswindow/hseditor/hscofeditor/cof_editor.go
+++ b/hswindow/hseditor/hscofeditor/cof_editor.go
@@ -44,7 +44,7 @@ func (e *COFEditor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hscofeditor/cof_editor.go
+++ b/hswindow/hseditor/hscofeditor/cof_editor.go
@@ -2,7 +2,10 @@ package hscofeditor
 
 import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2cof"
+	"github.com/OpenDiablo2/dialog"
 	g "github.com/ianling/giu"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hswidget"
@@ -10,14 +13,14 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	cof, err := d2cof.Load(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &COFEditor{
-		Editor: hseditor.New(pathEntry, x, y),
+		Editor: hseditor.New(pathEntry, x, y, project),
 		cof:    cof,
 	}
 
@@ -49,4 +52,26 @@ func (e *COFEditor) UpdateMainMenuLayout(l *g.Layout) {
 	})
 
 	*l = append(*l, m)
+}
+
+func (e *COFEditor) GenerateSaveData() []byte {
+	// TODO -- save real data for this editor
+	data, _ := e.Path.GetFileBytes()
+
+	return data
+}
+
+func (e *COFEditor) Save() {
+	e.Editor.Save(e)
+}
+
+func (e *COFEditor) Cleanup() {
+	if e.HasChanges(e) {
+		if shouldSave := dialog.Message("There are unsaved changes to %s, save before closing this editor?",
+			e.Path.FullPath).YesNo(); shouldSave {
+			e.Save()
+		}
+	}
+
+	e.Editor.Cleanup()
 }

--- a/hswindow/hseditor/hsdc6editor/dc6_editor.go
+++ b/hswindow/hseditor/hsdc6editor/dc6_editor.go
@@ -45,7 +45,7 @@ func (e *DC6Editor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hsdc6editor/dc6_editor.go
+++ b/hswindow/hseditor/hsdc6editor/dc6_editor.go
@@ -1,7 +1,10 @@
 package hsdc6editor
 
 import (
+	"github.com/OpenDiablo2/dialog"
 	g "github.com/ianling/giu"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hswidget"
@@ -11,14 +14,14 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	dc6, err := d2dc6.Load(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &DC6Editor{
-		Editor: hseditor.New(pathEntry, x, y),
+		Editor: hseditor.New(pathEntry, x, y, project),
 		dc6:    dc6,
 	}
 
@@ -50,4 +53,26 @@ func (e *DC6Editor) UpdateMainMenuLayout(l *g.Layout) {
 	})
 
 	*l = append(*l, m)
+}
+
+func (e *DC6Editor) GenerateSaveData() []byte {
+	// TODO -- save real data for this editor
+	data, _ := e.Path.GetFileBytes()
+
+	return data
+}
+
+func (e *DC6Editor) Save() {
+	e.Editor.Save(e)
+}
+
+func (e *DC6Editor) Cleanup() {
+	if e.HasChanges(e) {
+		if shouldSave := dialog.Message("There are unsaved changes to %s, save before closing this editor?",
+			e.Path.FullPath).YesNo(); shouldSave {
+			e.Save()
+		}
+	}
+
+	e.Editor.Cleanup()
 }

--- a/hswindow/hseditor/hsdcceditor/dcc_editor.go
+++ b/hswindow/hseditor/hsdcceditor/dcc_editor.go
@@ -44,7 +44,7 @@ func (e *DCCEditor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hsdcceditor/dcc_editor.go
+++ b/hswindow/hseditor/hsdcceditor/dcc_editor.go
@@ -2,7 +2,10 @@ package hsdcceditor
 
 import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dcc"
+	"github.com/OpenDiablo2/dialog"
 	g "github.com/ianling/giu"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hswidget"
@@ -10,14 +13,14 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	dcc, err := d2dcc.Load(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &DCCEditor{
-		Editor: hseditor.New(pathEntry, x, y),
+		Editor: hseditor.New(pathEntry, x, y, project),
 		dcc:    dcc,
 	}
 
@@ -49,4 +52,26 @@ func (e *DCCEditor) UpdateMainMenuLayout(l *g.Layout) {
 	})
 
 	*l = append(*l, m)
+}
+
+func (e *DCCEditor) GenerateSaveData() []byte {
+	// TODO -- save real data for this editor
+	data, _ := e.Path.GetFileBytes()
+
+	return data
+}
+
+func (e *DCCEditor) Save() {
+	e.Editor.Save(e)
+}
+
+func (e *DCCEditor) Cleanup() {
+	if e.HasChanges(e) {
+		if shouldSave := dialog.Message("There are unsaved changes to %s, save before closing this editor?",
+			e.Path.FullPath).YesNo(); shouldSave {
+			e.Save()
+		}
+	}
+
+	e.Editor.Cleanup()
 }

--- a/hswindow/hseditor/hsds1editor/ds1_editor.go
+++ b/hswindow/hseditor/hsds1editor/ds1_editor.go
@@ -1,7 +1,10 @@
 package hsds1editor
 
 import (
+	"github.com/OpenDiablo2/dialog"
 	g "github.com/ianling/giu"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2ds1"
 
@@ -12,14 +15,14 @@ import (
 
 var _ hscommon.EditorWindow = &DS1Editor{}
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	ds1, err := d2ds1.LoadDS1(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &DS1Editor{
-		Editor: hseditor.New(pathEntry, x, y),
+		Editor: hseditor.New(pathEntry, x, y, project),
 		ds1:    ds1,
 	}
 
@@ -55,4 +58,26 @@ func (e *DS1Editor) UpdateMainMenuLayout(l *g.Layout) {
 	})
 
 	*l = append(*l, m)
+}
+
+func (e *DS1Editor) GenerateSaveData() []byte {
+	// TODO -- save real data for this editor
+	data, _ := e.Path.GetFileBytes()
+
+	return data
+}
+
+func (e *DS1Editor) Save() {
+	e.Editor.Save(e)
+}
+
+func (e *DS1Editor) Cleanup() {
+	if e.HasChanges(e) {
+		if shouldSave := dialog.Message("There are unsaved changes to %s, save before closing this editor?",
+			e.Path.FullPath).YesNo(); shouldSave {
+			e.Save()
+		}
+	}
+
+	e.Editor.Cleanup()
 }

--- a/hswindow/hseditor/hsds1editor/ds1_editor.go
+++ b/hswindow/hseditor/hsds1editor/ds1_editor.go
@@ -50,7 +50,7 @@ func (e *DS1Editor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -2,7 +2,10 @@ package hsdt1editor
 
 import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dt1"
+	"github.com/OpenDiablo2/dialog"
 	g "github.com/ianling/giu"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
@@ -10,14 +13,14 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	dt1, err := d2dt1.LoadDT1(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &DT1Editor{
-		Editor:    hseditor.New(pathEntry, x, y),
+		Editor:    hseditor.New(pathEntry, x, y, project),
 		dt1:       dt1,
 		dt1Viewer: hswidget.DT1Viewer(pathEntry.GetUniqueId(), dt1),
 	}
@@ -65,4 +68,26 @@ func (e *DT1Editor) RegisterKeyboardShortcuts() {
 	hsinput.RegisterShortcut(func() {
 		e.dt1Viewer.SetTileGroup(e.dt1Viewer.TileGroup() - 1)
 	}, g.KeyLeft, g.ModNone, false)
+}
+
+func (e *DT1Editor) GenerateSaveData() []byte {
+	// TODO -- save real data for this editor
+	data, _ := e.Path.GetFileBytes()
+
+	return data
+}
+
+func (e *DT1Editor) Save() {
+	e.Editor.Save(e)
+}
+
+func (e *DT1Editor) Cleanup() {
+	if e.HasChanges(e) {
+		if shouldSave := dialog.Message("There are unsaved changes to %s, save before closing this editor?",
+			e.Path.FullPath).YesNo(); shouldSave {
+			e.Save()
+		}
+	}
+
+	e.Editor.Cleanup()
 }

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -49,7 +49,7 @@ func (e *DT1Editor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -36,7 +36,7 @@ func (e *DT1Editor) Build() {
 	e.IsOpen(&e.Visible).
 		Flags(g.WindowFlagsAlwaysAutoResize).
 		Layout(g.Layout{
-			hswidget.DT1Viewer(e.Path.GetUniqueId(), e.dt1),
+			e.dt1Viewer,
 		})
 }
 

--- a/hswindow/hseditor/hsfonteditor/fonteditor.go
+++ b/hswindow/hseditor/hsfonteditor/fonteditor.go
@@ -32,7 +32,7 @@ func (e *FontEditor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
+++ b/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/OpenDiablo2/dialog"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
+
 	g "github.com/ianling/giu"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
@@ -25,7 +29,7 @@ type fontGlyph struct {
 	width      int
 }
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	glyphs := make(fontTable)
 
 	table := *data
@@ -46,7 +50,7 @@ func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon
 	}
 
 	editor := &FontTableEditor{
-		Editor:    hseditor.New(pathEntry, x, y),
+		Editor:    hseditor.New(pathEntry, x, y, project),
 		fontTable: glyphs,
 	}
 
@@ -128,4 +132,26 @@ func (e *FontTableEditor) UpdateMainMenuLayout(l *g.Layout) {
 	})
 
 	*l = append(*l, m)
+}
+
+func (e *FontTableEditor) GenerateSaveData() []byte {
+	// TODO -- save real data for this editor
+	data, _ := e.Path.GetFileBytes()
+
+	return data
+}
+
+func (e *FontTableEditor) Save() {
+	e.Editor.Save(e)
+}
+
+func (e *FontTableEditor) Cleanup() {
+	if e.HasChanges(e) {
+		if shouldSave := dialog.Message("There are unsaved changes to %s, save before closing this editor?",
+			e.Path.FullPath).YesNo(); shouldSave {
+			e.Save()
+		}
+	}
+
+	e.Editor.Cleanup()
 }

--- a/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
+++ b/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
@@ -123,7 +123,7 @@ func (e *FontTableEditor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hspaletteeditor/palette_editor.go
+++ b/hswindow/hseditor/hspaletteeditor/palette_editor.go
@@ -45,7 +45,7 @@ func (e *PaletteEditor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hspaletteeditor/palette_editor.go
+++ b/hswindow/hseditor/hspaletteeditor/palette_editor.go
@@ -1,7 +1,10 @@
 package hspaletteeditor
 
 import (
+	"github.com/OpenDiablo2/dialog"
+
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 	"github.com/OpenDiablo2/HellSpawner/hswidget"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dat"
@@ -16,14 +19,14 @@ type PaletteEditor struct {
 	palette d2interface.Palette
 }
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	palette, err := d2dat.Load(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &PaletteEditor{
-		Editor:  hseditor.New(pathEntry, x, y),
+		Editor:  hseditor.New(pathEntry, x, y, project),
 		palette: palette,
 	}
 
@@ -50,4 +53,26 @@ func (e *PaletteEditor) UpdateMainMenuLayout(l *g.Layout) {
 	})
 
 	*l = append(*l, m)
+}
+
+func (e *PaletteEditor) GenerateSaveData() []byte {
+	// TODO -- save real data for this editor
+	data, _ := e.Path.GetFileBytes()
+
+	return data
+}
+
+func (e *PaletteEditor) Save() {
+	e.Editor.Save(e)
+}
+
+func (e *PaletteEditor) Cleanup() {
+	if e.HasChanges(e) {
+		if shouldSave := dialog.Message("There are unsaved changes to %s, save before closing this editor?",
+			e.Path.FullPath).YesNo(); shouldSave {
+			e.Save()
+		}
+	}
+
+	e.Editor.Cleanup()
 }

--- a/hswindow/hseditor/hspalettemapeditor/palette_map_editor.go
+++ b/hswindow/hseditor/hspalettemapeditor/palette_map_editor.go
@@ -2,7 +2,10 @@ package hspalettemapeditor
 
 import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2pl2"
+	"github.com/OpenDiablo2/dialog"
 	g "github.com/ianling/giu"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hswidget"
@@ -10,14 +13,14 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	pl2, err := d2pl2.Load(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &PaletteMapEditor{
-		Editor: hseditor.New(pathEntry, x, y),
+		Editor: hseditor.New(pathEntry, x, y, project),
 		pl2:    pl2,
 	}
 
@@ -51,4 +54,26 @@ func (e *PaletteMapEditor) UpdateMainMenuLayout(l *g.Layout) {
 	})
 
 	*l = append(*l, m)
+}
+
+func (e *PaletteMapEditor) GenerateSaveData() []byte {
+	// TODO -- save real data for this editor
+	data, _ := e.Path.GetFileBytes()
+
+	return data
+}
+
+func (e *PaletteMapEditor) Save() {
+	e.Editor.Save(e)
+}
+
+func (e *PaletteMapEditor) Cleanup() {
+	if e.HasChanges(e) {
+		if shouldSave := dialog.Message("There are unsaved changes to %s, save before closing this editor?",
+			e.Path.FullPath).YesNo(); shouldSave {
+			e.Save()
+		}
+	}
+
+	e.Editor.Cleanup()
 }

--- a/hswindow/hseditor/hspalettemapeditor/palette_map_editor.go
+++ b/hswindow/hseditor/hspalettemapeditor/palette_map_editor.go
@@ -46,7 +46,7 @@ func (e *PaletteMapEditor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hssoundeditor/soundeditor.go
+++ b/hswindow/hseditor/hssoundeditor/soundeditor.go
@@ -103,7 +103,7 @@ func (e *SoundEditor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
+++ b/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
@@ -2,6 +2,9 @@ package hsstringtableeditor
 
 import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2tbl"
+	"github.com/OpenDiablo2/dialog"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 
@@ -18,14 +21,14 @@ type StringTableEditor struct {
 	dict   d2tbl.TextDictionary
 }
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	dict, err := d2tbl.LoadTextDictionary(*data)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &StringTableEditor{
-		Editor: hseditor.New(pathEntry, x, y),
+		Editor: hseditor.New(pathEntry, x, y, project),
 		dict:   dict,
 	}
 
@@ -88,4 +91,26 @@ func (e *StringTableEditor) UpdateMainMenuLayout(l *g.Layout) {
 	})
 
 	*l = append(*l, m)
+}
+
+func (e *StringTableEditor) GenerateSaveData() []byte {
+	// TODO -- save real data for this editor
+	data, _ := e.Path.GetFileBytes()
+
+	return data
+}
+
+func (e *StringTableEditor) Save() {
+	e.Editor.Save(e)
+}
+
+func (e *StringTableEditor) Cleanup() {
+	if e.HasChanges(e) {
+		if shouldSave := dialog.Message("There are unsaved changes to %s, save before closing this editor?",
+			e.Path.FullPath).YesNo(); shouldSave {
+			e.Save()
+		}
+	}
+
+	e.Editor.Cleanup()
 }

--- a/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
+++ b/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
@@ -83,7 +83,7 @@ func (e *StringTableEditor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/hstexteditor/texteditor.go
+++ b/hswindow/hseditor/hstexteditor/texteditor.go
@@ -3,6 +3,10 @@ package hstexteditor
 import (
 	"strings"
 
+	"github.com/OpenDiablo2/dialog"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
+
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 
 	g "github.com/ianling/giu"
@@ -19,9 +23,9 @@ type TextEditor struct {
 	columns   int
 }
 
-func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32) (hscommon.EditorWindow, error) {
+func Create(pathEntry *hscommon.PathEntry, data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	result := &TextEditor{
-		Editor: hseditor.New(pathEntry, x, y),
+		Editor: hseditor.New(pathEntry, x, y, project),
 		text:   string(*data),
 	}
 
@@ -85,4 +89,26 @@ func (e *TextEditor) UpdateMainMenuLayout(l *g.Layout) {
 	})
 
 	*l = append(*l, m)
+}
+
+func (e *TextEditor) GenerateSaveData() []byte {
+	// TODO -- save real data for this editor
+	data, _ := e.Path.GetFileBytes()
+
+	return data
+}
+
+func (e *TextEditor) Save() {
+	e.Editor.Save(e)
+}
+
+func (e *TextEditor) Cleanup() {
+	if e.HasChanges(e) {
+		if shouldSave := dialog.Message("There are unsaved changes to %s, save before closing this editor?",
+			e.Path.FullPath).YesNo(); shouldSave {
+			e.Save()
+		}
+	}
+
+	e.Editor.Cleanup()
 }

--- a/hswindow/hseditor/hstexteditor/texteditor.go
+++ b/hswindow/hseditor/hstexteditor/texteditor.go
@@ -80,7 +80,7 @@ func (e *TextEditor) UpdateMainMenuLayout(l *g.Layout) {
 		g.MenuItem("Export to file...").OnClick(func() {}),
 		g.Separator(),
 		g.MenuItem("Close").OnClick(func() {
-			e.Visible = false
+			e.Cleanup()
 		}),
 	})
 

--- a/hswindow/hseditor/saveable.go
+++ b/hswindow/hseditor/saveable.go
@@ -1,0 +1,8 @@
+package hseditor
+
+// Saveable denotes a struct that has data that can be saved to a file.
+type Saveable interface {
+	// GenerateSaveData is called by the underlying interface (namely hseditor.Editor) to retrieve the data
+	// the editor wants written to the file.
+	GenerateSaveData() []byte
+}

--- a/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
+++ b/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
@@ -1,13 +1,14 @@
 package hsmpqexplorer
 
 import (
-	"github.com/OpenDiablo2/HellSpawner/hscommon/hsutil"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsutil"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsstate"
 


### PR DESCRIPTION
Sets up all the structure necessary for editor saving. Editors just have to implement the GenerateSaveData() function.

Adds fields to the Font Editor as an example, so you can now select the sprite, palette, and font table in the font editor and save the file.

If you have unsaved changes in an editor (only applies to the font editor right now obviously) and you attempt to close the editor, or close HellSpawner entirely, a dialog box will appear asking if you want to save your changes.

Ctrl+S will now also save the focused editor.