### PR TITLE
gitignore: added vim cache files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .vs
 .vscode
 
+# vim cache files
+*.swp
+
 # Binaries for programs and plugins
 *.exe
 *.exe~


### PR DESCRIPTION
Hi there,
sometimes `git add .` added vim cache (.swp)