### PR TITLE
hotfix: moved os.Exit from App.Quit() into Exit action in menubar

### DIFF
--- a/hsapp/app.go
+++ b/hsapp/app.go
@@ -2,7 +2,6 @@ package hsapp
 
 import (
 	"log"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -414,6 +413,4 @@ func (a *App) Quit() {
 	a.Save()
 
 	a.CloseAllOpenWindows()
-
-	os.Exit(0)
 }

--- a/hsapp/menubar.go
+++ b/hsapp/menubar.go
@@ -2,6 +2,7 @@ package hsapp
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/OpenDiablo2/dialog"
 
@@ -48,7 +49,10 @@ func (a *App) renderMainMenuBar() {
 			g.Separator(),
 			g.MenuItem("Preferences...\t\tAlt+P##MainMenuFilePreferences").OnClick(a.onFilePreferencesClicked),
 			g.Separator(),
-			g.MenuItem("Exit\t\t\t\t\t\t  Alt+Q##MainMenuFileExit").OnClick(a.Quit),
+			g.MenuItem("Exit\t\t\t\t\t\t  Alt+Q##MainMenuFileExit").OnClick(func() {
+				a.Quit()
+				os.Exit(0)
+			}),
 		}),
 		g.Menu("View##MainMenuView").Layout(a.buildViewMenu()),
 		g.Menu("Project##MainMenuProject").Layout(g.Layout{


### PR DESCRIPTION
Hi there,
now `File -> exit` closes app and panic messages are visible