### PR TITLE
animation (dcc, dc6, dt1) viewers: palette use feature

### DIFF
--- a/hsapp/app.go
+++ b/hsapp/app.go
@@ -73,6 +73,7 @@ type App struct {
 
 	editors            []hscommon.EditorWindow
 	editorConstructors map[hsfiletypes.FileType]func(
+		config *hsconfig.Config,
 		textureLoader *hscommon.TextureLoader,
 		pathEntry *hscommon.PathEntry,
 		data *[]byte,
@@ -98,6 +99,7 @@ func Create() (*App, error) {
 	result := &App{
 		editors: make([]hscommon.EditorWindow, 0),
 		editorConstructors: make(map[hsfiletypes.FileType]func(
+			config *hsconfig.Config,
 			textureLoader *hscommon.TextureLoader,
 			pathEntry *hscommon.PathEntry,
 			data *[]byte,
@@ -258,7 +260,7 @@ func (a *App) createEditor(path *hscommon.PathEntry, x, y float32) {
 		return
 	}
 
-	editor, err := a.editorConstructors[fileType](a.TextureLoader, path, &data, x, y, a.project)
+	editor, err := a.editorConstructors[fileType](a.config, a.TextureLoader, path, &data, x, y, a.project)
 
 	if err != nil {
 		dialog.Message("Error creating editor: %s", err).Error()

--- a/hswidget/dc6widget/state.go
+++ b/hswidget/dc6widget/state.go
@@ -93,6 +93,7 @@ func (p *widget) initState() {
 				}
 
 				var r, g, b uint8
+
 				if p.palette != nil {
 					col := p.palette[val]
 					r, g, b = col.R(), col.G(), col.B()
@@ -100,7 +101,6 @@ func (p *widget) initState() {
 					r, g, b = val, val, val
 				}
 
-				//newState.rgb[frameIndex].Set(x, y, color.RGBA{R: val, G: val, B: val, A: alpha})
 				newState.rgb[frameIndex].Set(
 					x, y,
 					color.RGBA{

--- a/hswidget/dc6widget/state.go
+++ b/hswidget/dc6widget/state.go
@@ -92,7 +92,24 @@ func (p *widget) initState() {
 					alpha = 0
 				}
 
-				newState.rgb[frameIndex].Set(x, y, color.RGBA{R: val, G: val, B: val, A: alpha})
+				var r, g, b uint8
+				if p.palette != nil {
+					col := p.palette[val]
+					r, g, b = col.R(), col.G(), col.B()
+				} else {
+					r, g, b = val, val, val
+				}
+
+				//newState.rgb[frameIndex].Set(x, y, color.RGBA{R: val, G: val, B: val, A: alpha})
+				newState.rgb[frameIndex].Set(
+					x, y,
+					color.RGBA{
+						R: r,
+						G: g,
+						B: b,
+						A: alpha,
+					},
+				)
 			}
 		}
 	}

--- a/hswidget/dc6widget/widget.go
+++ b/hswidget/dc6widget/widget.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ianling/imgui-go"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dc6"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 )
@@ -22,14 +23,16 @@ type widget struct {
 	id            string
 	dc6           *d2dc6.DC6
 	textureLoader *hscommon.TextureLoader
+	palette       *[256]d2interface.Color
 }
 
 // Create creates new widget
-func Create(textureLoader *hscommon.TextureLoader, id string, dc6 *d2dc6.DC6) giu.Widget {
+func Create(palette *[256]d2interface.Color, textureLoader *hscommon.TextureLoader, id string, dc6 *d2dc6.DC6) giu.Widget {
 	result := &widget{
 		id:            id,
 		dc6:           dc6,
 		textureLoader: textureLoader,
+		palette:       palette,
 	}
 
 	return result

--- a/hswidget/dccwidget/state.go
+++ b/hswidget/dccwidget/state.go
@@ -71,28 +71,8 @@ func (p *widget) initState() {
 
 					val := pixels[idx]
 
-					alpha := maxAlpha
-
-					if val == 0 {
-						alpha = 0
-					}
-
-					var r, g, b uint8
-					if p.palette != nil {
-						col := p.palette[val]
-						r, g, b = col.R(), col.G(), col.B()
-					} else {
-						r, g, b = val, val, val
-					}
-
-					RGBAcolor := color.RGBA{
-						R: r,
-						G: g,
-						B: b,
-						A: alpha,
-					}
-
-					images[absoluteFrameIdx].Set(x, y, RGBAcolor)
+					RGBAColor := p.makeImagePixel(val)
+					images[absoluteFrameIdx].Set(x, y, RGBAColor)
 				}
 			}
 		}
@@ -122,4 +102,30 @@ func (p *widget) initState() {
 
 func (p *widget) setState(s giu.Disposable) {
 	giu.Context.SetState(p.getStateID(), s)
+}
+
+func (p *widget) makeImagePixel(val byte) color.RGBA {
+	alpha := maxAlpha
+
+	if val == 0 {
+		alpha = 0
+	}
+
+	var r, g, b uint8
+
+	if p.palette != nil {
+		col := p.palette[val]
+		r, g, b = col.R(), col.G(), col.B()
+	} else {
+		r, g, b = val, val, val
+	}
+
+	RGBAColor := color.RGBA{
+		R: r,
+		G: g,
+		B: b,
+		A: alpha,
+	}
+
+	return RGBAColor
 }

--- a/hswidget/dccwidget/state.go
+++ b/hswidget/dccwidget/state.go
@@ -77,7 +77,20 @@ func (p *widget) initState() {
 						alpha = 0
 					}
 
-					RGBAcolor := color.RGBA{R: val, G: val, B: val, A: alpha}
+					var r, g, b uint8
+					if p.palette != nil {
+						col := p.palette[val]
+						r, g, b = col.R(), col.G(), col.B()
+					} else {
+						r, g, b = val, val, val
+					}
+
+					RGBAcolor := color.RGBA{
+						R: r,
+						G: g,
+						B: b,
+						A: alpha,
+					}
 
 					images[absoluteFrameIdx].Set(x, y, RGBAcolor)
 				}

--- a/hswidget/dccwidget/widget.go
+++ b/hswidget/dccwidget/widget.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ianling/imgui-go"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dcc"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
 
 const (
@@ -20,15 +21,17 @@ const (
 )
 
 type widget struct {
-	id  string
-	dcc *d2dcc.DCC
+	id      string
+	dcc     *d2dcc.DCC
+	palette *[256]d2interface.Color
 }
 
 // Create creates a new dcc widget
-func Create(id string, dcc *d2dcc.DCC) giu.Widget {
+func Create(palette *[256]d2interface.Color, id string, dcc *d2dcc.DCC) giu.Widget {
 	result := &widget{
-		id:  id,
-		dcc: dcc,
+		id:      id,
+		dcc:     dcc,
+		palette: palette,
 	}
 
 	return result

--- a/hswidget/select_palette_widget.go
+++ b/hswidget/select_palette_widget.go
@@ -107,7 +107,7 @@ func (p *SelectPaletteWidget) Build() {
 	giu.Layout{
 		giu.PopupModal("##" + p.id + "popUpSelectPalette").IsOpen(&isOpen).Layout(giu.Layout{
 			giu.Child("##"+p.id+"popUpSelectPaletteChildWidget").Size(paletteSelectW, paletteSelectH).Layout(giu.Layout{
-				giu.Layout(p.projectExplorer.GetProjectTreeNodes()),
+				p.projectExplorer.GetProjectTreeNodes(),
 				giu.Layout(p.mpqExplorer.GetMpqTreeNodes()),
 				giu.Separator(),
 				giu.Button("Don't use any palette##"+p.id+"selectPaletteDonotUseAny").

--- a/hswidget/select_palette_widget.go
+++ b/hswidget/select_palette_widget.go
@@ -1,0 +1,107 @@
+package hswidget
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/ianling/giu"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dat"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
+
+	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsfiletypes"
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
+	"github.com/OpenDiablo2/HellSpawner/hswindow/hstoolwindow/hsmpqexplorer"
+)
+
+const (
+	paletteSelectW, paletteSelectH = 400, 600
+	actionButtonW, actionButtonH   = 200, 30
+)
+
+// SelectPaletteWidget represents an pop-up MPQ explorer, when we're
+// selectin DAT palette
+type SelectPaletteWidget struct {
+	mpqExplorer *hsmpqexplorer.MPQExplorer
+	id          string
+	closeCB     func()
+}
+
+// NewSelectPaletteWidget creates a select palette widget
+func NewSelectPaletteWidget(
+	id string,
+	project *hsproject.Project,
+	config *hsconfig.Config,
+	saveCB func(colors *[256]d2interface.Color),
+	closeCB func(),
+) *SelectPaletteWidget {
+	result := &SelectPaletteWidget{
+		closeCB: closeCB,
+	}
+
+	onMpqSelect := func(path *hscommon.PathEntry) {
+		bytes, bytesErr := path.GetFileBytes()
+		if bytesErr != nil {
+			log.Print(bytesErr)
+
+			return
+		}
+
+		ft, err := hsfiletypes.GetFileTypeFromExtension(filepath.Ext(path.FullPath), &bytes)
+		if err != nil {
+			log.Print(err)
+
+			return
+		}
+
+		if ft == hsfiletypes.FileTypePalette {
+			// load new palette:
+			paletteData, err := path.GetFileBytes()
+			if err != nil {
+				log.Print(err)
+			}
+
+			palette, err := d2dat.Load(paletteData)
+			if err != nil {
+				log.Print(err)
+			}
+
+			colors := palette.GetColors()
+
+			saveCB(&colors)
+			closeCB()
+		}
+	}
+
+	mpqExplorer, err := hsmpqexplorer.Create(onMpqSelect, config, 0, 0)
+	if err != nil {
+		log.Print(err)
+	}
+
+	mpqExplorer.SetProject(project)
+
+	result.mpqExplorer = mpqExplorer
+
+	return result
+}
+
+// Build builds a widget
+func (p *SelectPaletteWidget) Build() {
+	// always true (we don't use this feature in this case
+	isOpen := true
+	giu.Layout{
+		giu.PopupModal("##" + p.id + "popUpSelectPalette").IsOpen(&isOpen).Layout(giu.Layout{
+			giu.Child("##"+p.id+"popUpSelectPaletteChildWidget").Size(paletteSelectW, paletteSelectH).Layout(giu.Layout{
+				giu.Layout(p.mpqExplorer.GetMpqTreeNodes()),
+				giu.Separator(),
+				giu.Button("Exit##"+p.id+"selectPaletteExit").
+					Size(actionButtonW, actionButtonH).
+					OnClick(func() {
+						p.closeCB()
+					}),
+			}),
+		}),
+	}.Build()
+}

--- a/hswindow/hseditor/hsanimdataeditor/animation_data_editor.go
+++ b/hswindow/hseditor/hsanimdataeditor/animation_data_editor.go
@@ -33,7 +33,8 @@ type AnimationDataEditor struct {
 }
 
 // Create creates a new cof editor
-func Create(tl *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	tl *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	d2, err := d2animdata.Load(*data)

--- a/hswindow/hseditor/hsanimdataeditor/animation_data_editor.go
+++ b/hswindow/hseditor/hsanimdataeditor/animation_data_editor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/animdatawidget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"

--- a/hswindow/hseditor/hscofeditor/cof_editor.go
+++ b/hswindow/hseditor/hscofeditor/cof_editor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
@@ -41,7 +42,7 @@ type COFEditor struct {
 }
 
 // Create creates a new cof editor
-func Create(tl *hscommon.TextureLoader,
+func Create(config *hsconfig.Config, tl *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	cof, err := d2cof.Unmarshal(*data)

--- a/hswindow/hseditor/hsdc6editor/dc6_editor.go
+++ b/hswindow/hseditor/hsdc6editor/dc6_editor.go
@@ -3,31 +3,20 @@ package hsdc6editor
 
 import (
 	"fmt"
-	"log"
-	"path/filepath"
 
 	"github.com/OpenDiablo2/dialog"
 	g "github.com/ianling/giu"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dat"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dc6"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 
-	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
-
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
-	"github.com/OpenDiablo2/HellSpawner/hscommon/hsfiletypes"
-	"github.com/OpenDiablo2/HellSpawner/hswidget/dc6widget"
-
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
+	"github.com/OpenDiablo2/HellSpawner/hswidget"
+	"github.com/OpenDiablo2/HellSpawner/hswidget/dc6widget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
-	"github.com/OpenDiablo2/HellSpawner/hswindow/hstoolwindow/hsmpqexplorer"
-)
-
-const (
-	paletteSelectW, paletteSelectH = 400, 600
-	actionButtonW, actionButtonH   = 200, 30
 )
 
 // static check, to ensure, if dc6 editor implemented editoWindow
@@ -36,12 +25,12 @@ var _ hscommon.EditorWindow = &DC6Editor{}
 // DC6Editor represents a dc6 editor
 type DC6Editor struct {
 	*hseditor.Editor
-	dc6           *d2dc6.DC6
-	textureLoader *hscommon.TextureLoader
-	config        *hsconfig.Config
-	selectPalette bool
-	palette       *[256]d2interface.Color
-	explorer      *hsmpqexplorer.MPQExplorer
+	dc6                 *d2dc6.DC6
+	textureLoader       *hscommon.TextureLoader
+	config              *hsconfig.Config
+	selectPalette       bool
+	palette             *[256]d2interface.Color
+	selectPaletteWidget g.Widget
 }
 
 // Create creates a new dc6 editor
@@ -78,73 +67,21 @@ func (e *DC6Editor) Build() {
 		return
 	}
 
-	// create mpq explorer if doesn't exist for now
-	if e.explorer == nil {
-		mpqExplorer, err := hsmpqexplorer.Create(
-			func(path *hscommon.PathEntry) {
-				bytes, bytesErr := path.GetFileBytes()
-				if bytesErr != nil {
-					log.Print(bytesErr)
-
-					return
-				}
-
-				ft, err := hsfiletypes.GetFileTypeFromExtension(filepath.Ext(path.FullPath), &bytes)
-				if err != nil {
-					log.Print(err)
-
-					return
-				}
-
-				if ft == hsfiletypes.FileTypePalette {
-					// load new palette:
-					paletteData, err := path.GetFileBytes()
-					if err != nil {
-						log.Print(err)
-					}
-
-					palette, err := d2dat.Load(paletteData)
-					if err != nil {
-						log.Print(err)
-					}
-
-					colors := palette.GetColors()
-
-					e.palette = &colors
-
-					e.selectPalette = false
-				}
-			},
+	if e.selectPaletteWidget == nil {
+		e.selectPaletteWidget = hswidget.NewSelectPaletteWidget(
+			e.Path.GetUniqueID()+"selectPalette",
+			e.Project,
 			e.config,
-			0, 0,
+			func(palette *[256]d2interface.Color) {
+				e.palette = palette
+			},
+			func() {
+				e.selectPalette = false
+			},
 		)
-
-		mpqExplorer.SetProject(e.Project)
-
-		if err != nil {
-			log.Print(err)
-
-			return
-		}
-
-		mpqExplorer.Visible = e.Visible
-
-		e.explorer = mpqExplorer
 	}
 
-	e.Layout(g.Layout{
-		g.PopupModal("something").IsOpen(&e.Visible).Layout(g.Layout{
-			g.Child("somethingChild").Size(paletteSelectW, paletteSelectH).Layout(g.Layout{
-				g.Layout(e.explorer.GetMpqTreeNodes()),
-				g.Separator(),
-				g.Button("Exit##"+e.Path.GetUniqueID()+"selectPaletteExit").
-					Size(actionButtonW, actionButtonH).
-					OnClick(func() {
-						e.selectPalette = false
-					}),
-			}),
-		}),
-	})
+	e.Layout(g.Layout{e.selectPaletteWidget})
 }
 
 // UpdateMainMenuLayout updates main menu to it contain DC6's editor menu

--- a/hswindow/hseditor/hsdc6editor/dc6_editor.go
+++ b/hswindow/hseditor/hsdc6editor/dc6_editor.go
@@ -135,7 +135,7 @@ func (e *DC6Editor) Build() {
 	e.Layout(g.Layout{
 		g.PopupModal("something").IsOpen(&e.Visible).Layout(g.Layout{
 			g.Child("somethingChild").Size(paletteSelectW, paletteSelectH).Layout(g.Layout{
-				e.explorer.Layout(),
+				g.Layout(e.explorer.GetMpqTreeNodes()),
 				g.Separator(),
 				g.Button("Exit##"+e.Path.GetUniqueID()+"selectPaletteExit").
 					Size(actionButtonW, actionButtonH).

--- a/hswindow/hseditor/hsdc6editor/dc6_editor.go
+++ b/hswindow/hseditor/hsdc6editor/dc6_editor.go
@@ -3,19 +3,31 @@ package hsdc6editor
 
 import (
 	"fmt"
+	"log"
+	"path/filepath"
 
 	"github.com/OpenDiablo2/dialog"
 	g "github.com/ianling/giu"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dat"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dc6"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
+
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsfiletypes"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/dc6widget"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dc6"
-
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
+	"github.com/OpenDiablo2/HellSpawner/hswindow/hstoolwindow/hsmpqexplorer"
+)
+
+const (
+	paletteSelectW, paletteSelectH = 400, 600
+	actionButtonW, actionButtonH   = 200, 30
 )
 
 // static check, to ensure, if dc6 editor implemented editoWindow
@@ -26,10 +38,15 @@ type DC6Editor struct {
 	*hseditor.Editor
 	dc6           *d2dc6.DC6
 	textureLoader *hscommon.TextureLoader
+	config        *hsconfig.Config
+	selectPalette bool
+	palette       *[256]d2interface.Color
+	explorer      *hsmpqexplorer.MPQExplorer
 }
 
 // Create creates a new dc6 editor
-func Create(textureLoader *hscommon.TextureLoader,
+func Create(config *hsconfig.Config,
+	textureLoader *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	dc6, err := d2dc6.Load(*data)
@@ -41,6 +58,8 @@ func Create(textureLoader *hscommon.TextureLoader,
 		Editor:        hseditor.New(pathEntry, x, y, project),
 		dc6:           dc6,
 		textureLoader: textureLoader,
+		selectPalette: false,
+		config:        config,
 	}
 
 	return result, nil
@@ -48,14 +67,90 @@ func Create(textureLoader *hscommon.TextureLoader,
 
 // Build builds a new dc6 editor
 func (e *DC6Editor) Build() {
-	e.IsOpen(&e.Visible).Flags(g.WindowFlagsAlwaysAutoResize).Layout(g.Layout{
-		dc6widget.Create(e.textureLoader, e.Path.GetUniqueID(), e.dc6),
+	e.IsOpen(&e.Visible)
+	e.Flags(g.WindowFlagsAlwaysAutoResize)
+	if !e.selectPalette {
+		e.Layout(g.Layout{
+			dc6widget.Create(e.palette, e.textureLoader, e.Path.GetUniqueID(), e.dc6),
+		})
+
+		return
+	}
+
+	// create mpq explorer if doesn't exist for now
+	if e.explorer == nil {
+		mpqExplorer, err := hsmpqexplorer.Create(
+			func(path *hscommon.PathEntry) {
+				bytes, bytesErr := path.GetFileBytes()
+				if bytesErr != nil {
+					log.Print(bytesErr)
+
+					return
+				}
+
+				ft, err := hsfiletypes.GetFileTypeFromExtension(filepath.Ext(path.FullPath), &bytes)
+				if err != nil {
+					log.Print(err)
+
+					return
+				}
+
+				if ft == hsfiletypes.FileTypePalette {
+
+					// load new palette:
+					paletteData, err := path.GetFileBytes()
+					if err != nil {
+						log.Print(err)
+					}
+
+					palette, err := d2dat.Load(paletteData)
+					if err != nil {
+						log.Print(err)
+					}
+
+					colors := palette.GetColors()
+
+					e.palette = &colors
+
+					e.selectPalette = false
+				}
+			},
+			e.config,
+			0, 0,
+		)
+		mpqExplorer.SetProject(e.Project)
+		if err != nil {
+			log.Print(err)
+
+			return
+		}
+		mpqExplorer.Visible = e.Visible
+
+		e.explorer = mpqExplorer
+	}
+
+	e.Layout(g.Layout{
+		g.PopupModal("something").IsOpen(&e.Visible).Layout(g.Layout{
+			g.Child("somethingChild").Size(paletteSelectW, paletteSelectH).Layout(g.Layout{
+				e.explorer.Layout(),
+				g.Separator(),
+				g.Button("Exit##"+e.Path.GetUniqueID()+"selectPaletteExit").
+					Size(actionButtonW, actionButtonH).
+					OnClick(func() {
+						e.selectPalette = false
+					}),
+			}),
+		}),
 	})
 }
 
 // UpdateMainMenuLayout updates main menu to it contain DC6's editor menu
 func (e *DC6Editor) UpdateMainMenuLayout(l *g.Layout) {
 	m := g.Menu("DC6 Editor").Layout(g.Layout{
+		g.MenuItem("Change Palette").OnClick(func() {
+			e.selectPalette = true
+		}),
+		g.Separator(),
 		g.MenuItem("Save\t\t\t\tCtrl+Shift+S").OnClick(e.Save),
 		g.Separator(),
 		g.MenuItem("Add to project").OnClick(func() {}),

--- a/hswindow/hseditor/hsdc6editor/dc6_editor.go
+++ b/hswindow/hseditor/hsdc6editor/dc6_editor.go
@@ -69,6 +69,7 @@ func Create(config *hsconfig.Config,
 func (e *DC6Editor) Build() {
 	e.IsOpen(&e.Visible)
 	e.Flags(g.WindowFlagsAlwaysAutoResize)
+
 	if !e.selectPalette {
 		e.Layout(g.Layout{
 			dc6widget.Create(e.palette, e.textureLoader, e.Path.GetUniqueID(), e.dc6),
@@ -96,7 +97,6 @@ func (e *DC6Editor) Build() {
 				}
 
 				if ft == hsfiletypes.FileTypePalette {
-
 					// load new palette:
 					paletteData, err := path.GetFileBytes()
 					if err != nil {
@@ -118,12 +118,15 @@ func (e *DC6Editor) Build() {
 			e.config,
 			0, 0,
 		)
+
 		mpqExplorer.SetProject(e.Project)
+
 		if err != nil {
 			log.Print(err)
 
 			return
 		}
+
 		mpqExplorer.Visible = e.Visible
 
 		e.explorer = mpqExplorer

--- a/hswindow/hseditor/hsdcceditor/dcc_editor.go
+++ b/hswindow/hseditor/hsdcceditor/dcc_editor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
+	"github.com/OpenDiablo2/HellSpawner/hswidget"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/dccwidget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
@@ -59,7 +60,7 @@ func (e *DCCEditor) Build() {
 
 	if !e.selectPalette {
 		e.Layout(g.Layout{
-			hswidget.DCCViewer(e.palette, e.Path.GetUniqueID(), e.dcc),
+			dccwidget.Create(e.palette, e.Path.GetUniqueID(), e.dcc),
 		})
 
 		return

--- a/hswindow/hseditor/hsdcceditor/dcc_editor.go
+++ b/hswindow/hseditor/hsdcceditor/dcc_editor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/dccwidget"
 
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
@@ -29,7 +30,8 @@ type DCCEditor struct {
 }
 
 // Create creates a new dcc editor
-func Create(_ *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	_ *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	dcc, err := d2dcc.Load(*data)

--- a/hswindow/hseditor/hsdcceditor/dcc_editor.go
+++ b/hswindow/hseditor/hsdcceditor/dcc_editor.go
@@ -132,7 +132,7 @@ func (e *DCCEditor) Build() {
 	e.Layout(g.Layout{
 		g.PopupModal("something").IsOpen(&e.Visible).Layout(g.Layout{
 			g.Child("somethingChild").Size(paletteSelectW, paletteSelectH).Layout(g.Layout{
-				e.explorer.Layout(),
+				g.Layout(e.explorer.GetMpqTreeNodes()),
 				g.Separator(),
 				g.Button("Exit##"+e.Path.GetUniqueID()+"selectPaletteExit").
 					Size(actionButtonW, actionButtonH).

--- a/hswindow/hseditor/hsds1editor/ds1_editor.go
+++ b/hswindow/hseditor/hsds1editor/ds1_editor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2ds1"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswidget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
@@ -27,7 +28,8 @@ type DS1Editor struct {
 }
 
 // Create creates a new ds1 editor
-func Create(_ *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	_ *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	ds1, err := d2ds1.LoadDS1(*data)

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -3,30 +3,20 @@ package hsdt1editor
 
 import (
 	"fmt"
-	"log"
-	"path/filepath"
 
 	g "github.com/ianling/giu"
 
 	"github.com/OpenDiablo2/dialog"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dat"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dt1"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
-	"github.com/OpenDiablo2/HellSpawner/hscommon/hsfiletypes"
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/dt1widget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
-	"github.com/OpenDiablo2/HellSpawner/hswindow/hstoolwindow/hsmpqexplorer"
-)
-
-const (
-	paletteSelectW, paletteSelectH = 400, 600
-	actionButtonW, actionButtonH   = 200, 30
 )
 
 // static check, to ensure, if dt1 editor implemented editoWindow
@@ -35,13 +25,13 @@ var _ hscommon.EditorWindow = &DT1Editor{}
 // DT1Editor represents a dt1 editor
 type DT1Editor struct {
 	*hseditor.Editor
-	dt1           *d2dt1.DT1
-	dt1Viewer     *hswidget.DT1ViewerWidget
-	config        *hsconfig.Config
-	selectPalette bool
-	palette       *[256]d2interface.Color
-	explorer      *hsmpqexplorer.MPQExplorer
-	textureLoader *hscommon.TextureLoader
+	dt1                 *d2dt1.DT1
+	dt1Viewer           *hswidget.DT1ViewerWidget
+	textureLoader       *hscommon.TextureLoader
+	config              *hsconfig.Config
+	selectPalette       bool
+	palette             *[256]d2interface.Color
+	selectPaletteWidget g.Widget
 }
 
 // Create creates new dt1 editor
@@ -80,72 +70,21 @@ func (e *DT1Editor) Build() {
 	}
 
 	// create mpq explorer if doesn't exist for now
-	if e.explorer == nil {
-		mpqExplorer, err := hsmpqexplorer.Create(
-			func(path *hscommon.PathEntry) {
-				bytes, bytesErr := path.GetFileBytes()
-				if bytesErr != nil {
-					log.Print(bytesErr)
-
-					return
-				}
-
-				ft, err := hsfiletypes.GetFileTypeFromExtension(filepath.Ext(path.FullPath), &bytes)
-				if err != nil {
-					log.Print(err)
-
-					return
-				}
-
-				if ft == hsfiletypes.FileTypePalette {
-					// load new palette:
-					paletteData, err := path.GetFileBytes()
-					if err != nil {
-						log.Print(err)
-					}
-
-					palette, err := d2dat.Load(paletteData)
-					if err != nil {
-						log.Print(err)
-					}
-
-					colors := palette.GetColors()
-
-					e.palette = &colors
-
-					e.selectPalette = false
-				}
-			},
+	if e.selectPaletteWidget == nil {
+		e.selectPaletteWidget = hswidget.NewSelectPaletteWidget(
+			e.Path.GetUniqueID(),
+			e.Project,
 			e.config,
-			0, 0,
+			func(colors *[256]d2interface.Color) {
+				e.palette = colors
+			},
+			func() {
+				e.selectPalette = false
+			},
 		)
-
-		mpqExplorer.SetProject(e.Project)
-
-		if err != nil {
-			log.Print(err)
-
-			return
-		}
-
-		mpqExplorer.Visible = e.Visible
-
-		e.explorer = mpqExplorer
 	}
 
-	e.Layout(g.Layout{
-		g.PopupModal("something").IsOpen(&e.Visible).Layout(g.Layout{
-			g.Child("somethingChild").Size(paletteSelectW, paletteSelectH).Layout(g.Layout{
-				g.Layout(e.explorer.GetMpqTreeNodes()),
-				g.Separator(),
-				g.Button("Exit##"+e.Path.GetUniqueID()+"selectPaletteExit").
-					Size(actionButtonW, actionButtonH).
-					OnClick(func() {
-						e.selectPalette = false
-					}),
-			}),
-		}),
-	})
+	e.Layout(g.Layout{e.selectPaletteWidget})
 }
 
 // UpdateMainMenuLayout updates main menu layout to it contains editors options

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -3,19 +3,30 @@ package hsdt1editor
 
 import (
 	"fmt"
+	"log"
+	"path/filepath"
 
 	g "github.com/ianling/giu"
 
 	"github.com/OpenDiablo2/dialog"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dat"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dt1"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hscommon/hsfiletypes"
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/dt1widget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
+	"github.com/OpenDiablo2/HellSpawner/hswindow/hstoolwindow/hsmpqexplorer"
+)
+
+const (
+	paletteSelectW, paletteSelectH = 400, 600
+	actionButtonW, actionButtonH   = 200, 30
 )
 
 // static check, to ensure, if dt1 editor implemented editoWindow
@@ -25,11 +36,16 @@ var _ hscommon.EditorWindow = &DT1Editor{}
 type DT1Editor struct {
 	*hseditor.Editor
 	dt1           *d2dt1.DT1
+	dt1Viewer     *hswidget.DT1ViewerWidget
+	config        *hsconfig.Config
+	selectPalette bool
+	palette       *[256]d2interface.Color
+	explorer      *hsmpqexplorer.MPQExplorer
 	textureLoader *hscommon.TextureLoader
 }
 
 // Create creates new dt1 editor
-func Create(_ *hsconfig.Config,
+func Create(config *hsconfig.Config,
 	textureLoader *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
@@ -41,6 +57,8 @@ func Create(_ *hsconfig.Config,
 	result := &DT1Editor{
 		Editor:        hseditor.New(pathEntry, x, y, project),
 		dt1:           dt1,
+		config:        config,
+		selectPalette: false,
 		textureLoader: textureLoader,
 	}
 
@@ -49,16 +67,94 @@ func Create(_ *hsconfig.Config,
 
 // Build prepares the editor for rendering, but does not actually render it
 func (e *DT1Editor) Build() {
-	e.IsOpen(&e.Visible).
-		Flags(g.WindowFlagsAlwaysAutoResize).
-		Layout(g.Layout{
-			dt1widget.Create(e.textureLoader, e.Path.GetUniqueID(), e.dt1),
+	e.IsOpen(&e.Visible)
+	e.Flags(g.WindowFlagsAlwaysAutoResize)
+
+	if !e.selectPalette {
+		dt1Viewer := hswidget.DT1Viewer(e.palette, e.textureLoader, e.Path.GetUniqueID(), e.dt1)
+		e.Layout(g.Layout{
+			dt1Viewer,
 		})
+
+		return
+	}
+
+	// create mpq explorer if doesn't exist for now
+	if e.explorer == nil {
+		mpqExplorer, err := hsmpqexplorer.Create(
+			func(path *hscommon.PathEntry) {
+				bytes, bytesErr := path.GetFileBytes()
+				if bytesErr != nil {
+					log.Print(bytesErr)
+
+					return
+				}
+
+				ft, err := hsfiletypes.GetFileTypeFromExtension(filepath.Ext(path.FullPath), &bytes)
+				if err != nil {
+					log.Print(err)
+
+					return
+				}
+
+				if ft == hsfiletypes.FileTypePalette {
+					// load new palette:
+					paletteData, err := path.GetFileBytes()
+					if err != nil {
+						log.Print(err)
+					}
+
+					palette, err := d2dat.Load(paletteData)
+					if err != nil {
+						log.Print(err)
+					}
+
+					colors := palette.GetColors()
+
+					e.palette = &colors
+
+					e.selectPalette = false
+				}
+			},
+			e.config,
+			0, 0,
+		)
+
+		mpqExplorer.SetProject(e.Project)
+
+		if err != nil {
+			log.Print(err)
+
+			return
+		}
+
+		mpqExplorer.Visible = e.Visible
+
+		e.explorer = mpqExplorer
+	}
+
+	e.Layout(g.Layout{
+		g.PopupModal("something").IsOpen(&e.Visible).Layout(g.Layout{
+			g.Child("somethingChild").Size(paletteSelectW, paletteSelectH).Layout(g.Layout{
+				e.explorer.Layout(),
+				g.Separator(),
+				g.Button("Exit##"+e.Path.GetUniqueID()+"selectPaletteExit").
+					Size(actionButtonW, actionButtonH).
+					OnClick(func() {
+						e.selectPalette = false
+					}),
+			}),
+		}),
+	})
 }
 
 // UpdateMainMenuLayout updates main menu layout to it contains editors options
 func (e *DT1Editor) UpdateMainMenuLayout(l *g.Layout) {
 	m := g.Menu("DT1 Editor").Layout(g.Layout{
+		g.MenuItem("Change Palette").OnClick(func() {
+			e.selectPalette = true
+		}),
+		g.Separator(),
 		g.MenuItem("Save\t\t\t\tCtrl+Shift+S").OnClick(e.Save),
 		g.Separator(),
 		g.MenuItem("Add to project").OnClick(func() {}),

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -136,7 +136,7 @@ func (e *DT1Editor) Build() {
 	e.Layout(g.Layout{
 		g.PopupModal("something").IsOpen(&e.Visible).Layout(g.Layout{
 			g.Child("somethingChild").Size(paletteSelectW, paletteSelectH).Layout(g.Layout{
-				e.explorer.Layout(),
+				g.Layout(e.explorer.GetMpqTreeNodes()),
 				g.Separator(),
 				g.Button("Exit##"+e.Path.GetUniqueID()+"selectPaletteExit").
 					Size(actionButtonW, actionButtonH).

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/dt1widget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
@@ -28,7 +29,8 @@ type DT1Editor struct {
 }
 
 // Create creates new dt1 editor
-func Create(textureLoader *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	textureLoader *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	dt1, err := d2dt1.LoadDT1(*data)

--- a/hswindow/hseditor/hsdt1editor/dt1_editor.go
+++ b/hswindow/hseditor/hsdt1editor/dt1_editor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
+	"github.com/OpenDiablo2/HellSpawner/hswidget"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/dt1widget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
@@ -26,7 +27,6 @@ var _ hscommon.EditorWindow = &DT1Editor{}
 type DT1Editor struct {
 	*hseditor.Editor
 	dt1                 *d2dt1.DT1
-	dt1Viewer           *hswidget.DT1ViewerWidget
 	textureLoader       *hscommon.TextureLoader
 	config              *hsconfig.Config
 	selectPalette       bool
@@ -61,7 +61,7 @@ func (e *DT1Editor) Build() {
 	e.Flags(g.WindowFlagsAlwaysAutoResize)
 
 	if !e.selectPalette {
-		dt1Viewer := hswidget.DT1Viewer(e.palette, e.textureLoader, e.Path.GetUniqueID(), e.dt1)
+		dt1Viewer := dt1widget.Create(e.palette, e.textureLoader, e.Path.GetUniqueID(), e.dt1)
 		e.Layout(g.Layout{
 			dt1Viewer,
 		})

--- a/hswindow/hseditor/hsfonteditor/fonteditor.go
+++ b/hswindow/hseditor/hsfonteditor/fonteditor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
 
@@ -30,7 +31,8 @@ type FontEditor struct {
 }
 
 // Create creates a new font editor
-func Create(_ *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	_ *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	font, err := hsfont.LoadFromJSON(*data)

--- a/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
+++ b/hswindow/hseditor/hsfonttableeditor/font_table_editor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/fonttablewidget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
@@ -36,7 +37,8 @@ type FontTableEditor struct {
 }
 
 // Create creates a new font table editor
-func Create(tl *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	tl *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	table, err := d2font.Load(*data)

--- a/hswindow/hseditor/hspaletteeditor/palette_editor.go
+++ b/hswindow/hseditor/hspaletteeditor/palette_editor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/palettegrideditorwidget"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/palettegridwidget"
@@ -30,7 +31,8 @@ type PaletteEditor struct {
 }
 
 // Create creates a new palette editor
-func Create(tl *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	tl *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	palette, err := d2dat.Load(*data)

--- a/hswindow/hseditor/hspalettemapeditor/palette_map_editor.go
+++ b/hswindow/hseditor/hspalettemapeditor/palette_map_editor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswidget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
@@ -28,7 +29,8 @@ type PaletteMapEditor struct {
 }
 
 // Create creates a new palette map editor
-func Create(textureLoader *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	textureLoader *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	pl2, err := d2pl2.Load(*data)

--- a/hswindow/hseditor/hssoundeditor/soundeditor.go
+++ b/hswindow/hseditor/hssoundeditor/soundeditor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/faiface/beep/speaker"
 	"github.com/faiface/beep/wav"
 
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 
 	g "github.com/ianling/giu"
@@ -42,7 +43,8 @@ type SoundEditor struct {
 }
 
 // Create creates a new sound editor
-func Create(_ *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	_ *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	streamer, format, err := wav.Decode(bytes.NewReader(*data))

--- a/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
+++ b/hswindow/hseditor/hsstringtableeditor/string_table_editor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswidget/stringtablewidget"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
@@ -31,7 +32,8 @@ type StringTableEditor struct {
 }
 
 // Create creates a new string table editor
-func Create(_ *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	_ *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	dict, err := d2tbl.LoadTextDictionary(*data)

--- a/hswindow/hseditor/hstexteditor/texteditor.go
+++ b/hswindow/hseditor/hstexteditor/texteditor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/OpenDiablo2/HellSpawner/hscommon"
 	"github.com/OpenDiablo2/HellSpawner/hscommon/hsproject"
+	"github.com/OpenDiablo2/HellSpawner/hsconfig"
 	"github.com/OpenDiablo2/HellSpawner/hsinput"
 	"github.com/OpenDiablo2/HellSpawner/hswindow/hseditor"
 )
@@ -33,7 +34,8 @@ type TextEditor struct {
 }
 
 // Create creates a new text editor
-func Create(_ *hscommon.TextureLoader,
+func Create(_ *hsconfig.Config,
+	_ *hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	data *[]byte, x, y float32, project *hsproject.Project) (hscommon.EditorWindow, error) {
 	result := &TextEditor{

--- a/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
+++ b/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
@@ -94,16 +94,12 @@ func (m *MPQExplorer) Build() {
 			g.Child("MpqExplorerContent").
 				Border(false).
 				Flags(g.WindowFlagsHorizontalScrollbar).
-				Layout(m.getMpqTreeNodes()),
+				Layout(m.GetMpqTreeNodes()),
 		})
 }
 
-// Layout returns mpq explorer without using hstoolwindow.ToolWindow
-func (m *MPQExplorer) Layout() g.Layout {
-	return g.Layout(m.getMpqTreeNodes())
-}
-
-func (m *MPQExplorer) getMpqTreeNodes() []g.Widget {
+// GetMpqTreeNodes returns mpq tree
+func (m *MPQExplorer) GetMpqTreeNodes() []g.Widget {
 	if m.nodeCache != nil {
 		return m.nodeCache
 	}

--- a/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
+++ b/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
@@ -84,15 +84,23 @@ func (m *MPQExplorer) Build() {
 					}),
 				),
 			})})
-	} else {
-		m.IsOpen(&m.Visible).
-			Size(mainWindowW, mainWindowH).
-			Layout(g.Layout{
-				g.Child("MpqExplorerContent").
-					Border(false).
-					Flags(g.WindowFlagsHorizontalScrollbar).
-					Layout(m.getMpqTreeNodes()),
-			})
+
+		return
+	}
+
+	m.IsOpen(&m.Visible).
+		Size(mainWindowW, mainWindowH).
+		Layout(g.Layout{
+			g.Child("MpqExplorerContent").
+				Border(false).
+				Flags(g.WindowFlagsHorizontalScrollbar).
+				Layout(m.getMpqTreeNodes()),
+		})
+}
+
+func (m *MPQExplorer) Layout() g.Layout {
+	return g.Layout{
+		g.Layout(m.getMpqTreeNodes()),
 	}
 }
 

--- a/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
+++ b/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
@@ -98,10 +98,9 @@ func (m *MPQExplorer) Build() {
 		})
 }
 
+// Layout returns mpq explorer without using hstoolwindow.ToolWindow
 func (m *MPQExplorer) Layout() g.Layout {
-	return g.Layout{
-		g.Layout(m.getMpqTreeNodes()),
-	}
+	return g.Layout(m.getMpqTreeNodes())
 }
 
 func (m *MPQExplorer) getMpqTreeNodes() []g.Widget {

--- a/hswindow/hstoolwindow/hsprojectexplorer/projectexplorer.go
+++ b/hswindow/hstoolwindow/hsprojectexplorer/projectexplorer.go
@@ -60,9 +60,11 @@ func Create(textureLoader *hscommon.TextureLoader,
 	}
 	result.Visible = false
 
-	textureLoader.CreateTextureFromFileAsync(refreshItemButtonPath, func(texture *g.Texture) {
-		result.refreshIconTexture = texture
-	})
+	if textureLoader != nil {
+		textureLoader.CreateTextureFromFileAsync(refreshItemButtonPath, func(texture *g.Texture) {
+			result.refreshIconTexture = texture
+		})
+	}
 
 	return result, nil
 }
@@ -84,7 +86,7 @@ func (m *ProjectExplorer) Build() {
 
 	tree := g.Child("ProjectExplorerProjectTreeContainer").
 		Flags(g.WindowFlagsHorizontalScrollbar).
-		Layout(m.getProjectTreeNodes())
+		Layout(m.GetProjectTreeNodes())
 
 	m.IsOpen(&m.Visible).
 		Size(mainWindowW, mainWindowH).
@@ -128,7 +130,7 @@ func (m *ProjectExplorer) makeRefreshButtonLayout() g.Layout {
 	}
 }
 
-func (m *ProjectExplorer) getProjectTreeNodes() g.Layout {
+func (m *ProjectExplorer) GetProjectTreeNodes() g.Layout {
 	if m.project == nil {
 		return []g.Widget{g.Label("No project loaded...")}
 	}

--- a/hswindow/hstoolwindow/hsprojectexplorer/projectexplorer.go
+++ b/hswindow/hstoolwindow/hsprojectexplorer/projectexplorer.go
@@ -130,6 +130,7 @@ func (m *ProjectExplorer) makeRefreshButtonLayout() g.Layout {
 	}
 }
 
+// GetProjectTreeNodes returns project tree
 func (m *ProjectExplorer) GetProjectTreeNodes() g.Layout {
 	if m.project == nil {
 		return []g.Widget{g.Label("No project loaded...")}


### PR DESCRIPTION
Hi there,
sometimes it was hard to identity what does dc6 animation show ;-). Now we can ask DC6, DCC and DT1 editor to use DAT palette

https://user-images.githubusercontent.com/73652197/111068160-e200e580-84c7-11eb-8c1c-73343876a83f.mp4


https://user-images.githubusercontent.com/73652197/111069955-c4d01500-84cf-11eb-9ef9-dccd902b8e8f.mp4

