### PR TITLE
hotfix: lintfix: update to golangci-lint 1.39 requirements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,7 @@ linters:
     - nakedret
     - nolintlint
     - prealloc
+    - revive
     - rowserrcheck
     - staticcheck
     - structcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
     - dupl
     - errcheck
     - errorlint
+    - exportloopref
     - funlen
     - gochecknoglobals
     - gochecknoinits
@@ -66,7 +67,6 @@ linters:
     - nolintlint
     - prealloc
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck
@@ -75,6 +75,7 @@ linters:
     - unparam
     - unused
     - varcheck
+    - wastedassign
     - whitespace
     - wrapcheck
     - wsl

--- a/abysswrapper/abysswrapper.go
+++ b/abysswrapper/abysswrapper.go
@@ -40,7 +40,12 @@ func (a *AbyssWrapper) Read(p []byte) (n int, err error) {
 }
 
 func (a *AbyssWrapper) Write(p []byte) (n int, err error) {
-	return a.output.Write(p)
+	n, err = a.output.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("error writing to output: %w", err)
+	}
+
+	return n, nil
 }
 
 // Launch launchs abyss wrapper
@@ -89,7 +94,11 @@ func (a *AbyssWrapper) Kill() error {
 		return nil
 	}
 
-	return a.cmd.Process.Kill()
+	if err := a.cmd.Process.Kill(); err != nil {
+		return fmt.Errorf("error closing AbyssWrapper: %w", err)
+	}
+
+	return nil
 }
 
 // IsRunning returns true, if AbyssWrapper is running

--- a/hscommon/hsfiletypes/hsfont/font.go
+++ b/hscommon/hsfiletypes/hsfont/font.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	newFilePerms = 0644
+	newFilePerms = 0o644
 )
 
 // Font represents font
@@ -35,7 +35,7 @@ func NewFile(filePath string) (*Font, error) {
 
 // LoadFromJSON loads a new font from json
 func LoadFromJSON(data []byte) (*Font, error) {
-	var font *Font = &Font{}
+	font := &Font{}
 
 	err := json.Unmarshal(data, font)
 	if err != nil {

--- a/hscommon/hsproject/mpq.go
+++ b/hscommon/hsproject/mpq.go
@@ -3,6 +3,7 @@ package hsproject
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -25,7 +26,6 @@ func (p *Project) GetMPQFileNodes(mpq d2interface.Archive, config *hsconfig.Conf
 	}
 
 	files, err := mpq.Listfile()
-
 	if err != nil {
 		files, err = p.searchForMpqFiles(mpq, config)
 		if err != nil {
@@ -94,7 +94,11 @@ func (p *Project) searchForMpqFiles(mpq d2interface.Archive, config *hsconfig.Co
 			}
 		}
 
-		return files, scanner.Err()
+		if err := scanner.Err(); err != nil {
+			return files, fmt.Errorf("error scanning for file: %w", err)
+		}
+
+		return files, nil
 	}
 
 	return files, nil

--- a/hscommon/pathentry.go
+++ b/hscommon/pathentry.go
@@ -67,7 +67,12 @@ func (p *PathEntry) GetFileBytes() ([]byte, error) {
 			return nil, fmt.Errorf("cannot get informations about file %s: %w", p.FullPath, err)
 		}
 
-		return ioutil.ReadFile(p.FullPath)
+		data, err := ioutil.ReadFile(p.FullPath)
+		if err != nil {
+			return nil, fmt.Errorf("error reading file: %w", err)
+		}
+
+		return data, nil
 	}
 
 	mpq, err := d2mpq.FromFile(p.MPQFile)
@@ -76,7 +81,10 @@ func (p *PathEntry) GetFileBytes() ([]byte, error) {
 	}
 
 	if mpq.Contains(p.FullPath) {
-		return mpq.ReadFile(p.FullPath)
+		data, err := mpq.ReadFile(p.FullPath)
+		if err != nil {
+			return data, fmt.Errorf("error reading file from mpq: %w", err)
+		}
 	}
 
 	return nil, errors.New("could not locate file in mpq")

--- a/hswidget/ds1viewer.go
+++ b/hswidget/ds1viewer.go
@@ -223,9 +223,7 @@ func (p *DS1ViewerWidget) makeTilesLayout(state *DS1ViewerState) giu.Layout {
 		p.setState(state)
 	}
 
-	numRows, numCols := 0, 0
-
-	numRows = len(p.ds1.Tiles)
+	numRows := len(p.ds1.Tiles)
 	if numRows < 1 {
 		return l
 	}
@@ -235,8 +233,7 @@ func (p *DS1ViewerWidget) makeTilesLayout(state *DS1ViewerState) giu.Layout {
 		p.setState(state)
 	}
 
-	numCols = len(p.ds1.Tiles[0])
-	if tx >= numCols {
+	if numCols := len(p.ds1.Tiles[0]); tx >= numCols {
 		state.ds1Controls.tileX = int32(numCols - 1)
 		p.setState(state)
 	}


### PR DESCRIPTION
- fixed exisiting lint errors
- remove deprecated scopelint linter
- add wastedasign linter and fixed wastedasign lints
- add revive linter