### PR TITLE
fixed bug where autosave only happened once

### DIFF
--- a/hsapp/app.go
+++ b/hsapp/app.go
@@ -149,8 +149,10 @@ func (a *App) Run() {
 
 	// initialize auto-save timer
 	go func() {
-		time.Sleep(autoSaveTimer * time.Second)
-		a.Save()
+		for {
+			time.Sleep(autoSaveTimer * time.Second)
+			a.Save()
+		}
 	}()
 
 	a.TextureLoader.ProcessTextureLoadRequests()


### PR DESCRIPTION
The fix was simple, there just wasn't a loop in the go routine that did the save. 