### PR TITLE
Fix build, remove lint errors (resolves #323)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go environment
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.16
+          go-version: 1.16.5
         id: go
 
       - name: Cache Go modules

--- a/abysswrapper/abysswrapper.go
+++ b/abysswrapper/abysswrapper.go
@@ -48,7 +48,7 @@ func (a *AbyssWrapper) Write(p []byte) (n int, err error) {
 	return n, nil
 }
 
-// Launch launchs abyss wrapper
+// Launch launches abyss wrapper
 func (a *AbyssWrapper) Launch(config *hsconfig.Config, output io.Writer) error {
 	a.mutex.RLock()
 	if a.running {

--- a/hsassets/assets.go
+++ b/hsassets/assets.go
@@ -4,7 +4,7 @@ import (
 	_ "embed" // this is standard solution for embed
 )
 
-// these variables are links to existing icones used in project
+// these variables are links to existing icons used in project
 // nolint:gochecknoglobals // go:embed directive works only for globals
 // https://github.com/golangci/golangci-lint/issues/1727
 var (

--- a/hscommon/hsfiletypes/filetype.go
+++ b/hscommon/hsfiletypes/filetype.go
@@ -94,9 +94,9 @@ func (f FileType) FileExtension() string {
 
 type fileTypeCheckFn = func(data *[]byte) FileType
 
-// SubtypeCheckFn returns a function to check a file. This is important for
+// subtypeCheckFn returns a function to check a file. This is important for
 // distinguishing between files that share a common file extension.
-func (f FileType) SubtypeCheckFn() fileTypeCheckFn {
+func (f FileType) subtypeCheckFn() fileTypeCheckFn {
 	table := map[FileType]fileTypeCheckFn{
 		FileTypeTBL:            determineSubtypeTBL,
 		FileTypeTBLFontTable:   determineSubtypeTBL,
@@ -114,7 +114,7 @@ func GetFileTypeFromExtension(extension string, data *[]byte) (FileType, error) 
 			continue
 		}
 
-		fnDetermine := fileType.SubtypeCheckFn()
+		fnDetermine := fileType.subtypeCheckFn()
 		if fnDetermine == nil {
 			return fileType, nil
 		}

--- a/hscommon/hsnode/node.go
+++ b/hscommon/hsnode/node.go
@@ -1,4 +1,4 @@
-// Package hsnode contains game nodes
+// Package hsnode contains an implementation of a node graph, as parent and child nodes.
 package hsnode
 
 import "strings"

--- a/hscommon/hsutil/datautils.go
+++ b/hscommon/hsutil/datautils.go
@@ -48,7 +48,7 @@ func ExportToGif(images []*image.RGBA, delay int32) error {
 	// reload static image and construct outGif
 	for _, img := range images {
 		// FROM TUTORIAL:
-		// Read each frame GIF image with gif.Decode. If we read JPEG images, we have to convert them programatically
+		// Read each frame GIF image with gif.Decode. If we read JPEG images, we have to convert them programmatically
 		// (goanigiffy does this by calling gif.Encode and gif.Decode).
 		g := bytes.NewBuffer([]byte{})
 

--- a/hscommon/hsutil/datautils.go
+++ b/hscommon/hsutil/datautils.go
@@ -14,7 +14,7 @@ import (
 
 const milliseconds = 1000
 
-// BoolToInt converts bool into 32-bit intager
+// BoolToInt converts bool into 32-bit integer
 // if b is true, then returns 1, else 0
 func BoolToInt(b bool) int32 {
 	if b {

--- a/hscommon/hsutil/datautils.go
+++ b/hscommon/hsutil/datautils.go
@@ -12,7 +12,7 @@ import (
 	"github.com/OpenDiablo2/dialog"
 )
 
-const miliseconds = 1000
+const milliseconds = 1000
 
 // BoolToInt converts bool into 32-bit intager
 // if b is true, then returns 1, else 0
@@ -63,7 +63,7 @@ func ExportToGif(images []*image.RGBA, delay int32) error {
 		}
 
 		outGif.Image = append(outGif.Image, inGif.(*image.Paletted))
-		outGif.Delay = append(outGif.Delay, int(delay/miliseconds))
+		outGif.Delay = append(outGif.Delay, int(delay/milliseconds))
 	}
 
 	// save gif image

--- a/hscommon/hsutil/datautils.go
+++ b/hscommon/hsutil/datautils.go
@@ -67,7 +67,7 @@ func ExportToGif(images []*image.RGBA, delay int32) error {
 	}
 
 	// save gif image
-	file, err := os.OpenFile(filepath.Clean(filePath), os.O_WRONLY|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(filepath.Clean(filePath), os.O_WRONLY|os.O_CREATE, defaultFilePermissions)
 	if err != nil {
 		return fmt.Errorf("error creating a new file: %w", err)
 	}

--- a/hsconfig/doc.go
+++ b/hsconfig/doc.go
@@ -1,2 +1,2 @@
-// Package hsconfig contains app configs
+// Package hsconfig provides the Hellspawner application config file implementation.
 package hsconfig

--- a/hswidget/animdatawidget/widget.go
+++ b/hswidget/animdatawidget/widget.go
@@ -73,12 +73,14 @@ func (p *widget) buildAnimationsList() {
 
 	list := make([]giu.Widget, len(keys))
 
+	const imageButtonSize = 13
+
 	for idx, name := range keys {
 		currentIdx := idx
 		list[idx] = giu.Row(
 			hswidget.MakeImageButton(
 				"##"+p.id+"deleteEntry"+strconv.Itoa(currentIdx),
-				13, 13,
+				imageButtonSize, imageButtonSize,
 				state.deleteIcon,
 				func() {
 					p.deleteEntry(state.mapKeys[currentIdx])

--- a/hswidget/cofwidget/state.go
+++ b/hswidget/cofwidget/state.go
@@ -130,7 +130,7 @@ func (s *widgetState) Decode(data []byte) {
 		return
 	}
 
-	s.selectable = (selectable == 1)
+	s.selectable = selectable == 1
 
 	transparent, err := sr.ReadByte()
 	if err != nil {
@@ -139,7 +139,7 @@ func (s *widgetState) Decode(data []byte) {
 		return
 	}
 
-	s.transparent = (transparent == 1)
+	s.transparent = transparent == 1
 
 	s.drawEffect, err = sr.ReadInt32()
 	if err != nil {

--- a/hswidget/cofwidget/widget.go
+++ b/hswidget/cofwidget/widget.go
@@ -421,12 +421,12 @@ func (p *widget) makeAddLayerLayout() giu.Layout {
 
 	drawEffectList := make([]string, d2enum.DrawEffectNone+1)
 	for i := d2enum.DrawEffectPctTransparency25; i <= d2enum.DrawEffectNone; i++ {
-		drawEffectList[int(i)] = strconv.Itoa(int(i)) + " (" + i.String() + ")"
+		drawEffectList[i] = strconv.Itoa(int(i)) + " (" + i.String() + ")"
 	}
 
 	weaponClassList := make([]string, d2enum.WeaponClassTwoHandToHand+1)
 	for i := d2enum.WeaponClassNone; i <= d2enum.WeaponClassTwoHandToHand; i++ {
-		weaponClassList[int(i)] = i.String() + " (" + i.Name() + ")"
+		weaponClassList[i] = i.String() + " (" + i.Name() + ")"
 	}
 
 	return giu.Layout{

--- a/hswidget/dc6widget/widget.go
+++ b/hswidget/dc6widget/widget.go
@@ -118,7 +118,9 @@ func (p *widget) makeViewerLayout() giu.Layout {
 				imgui.SliderInt("Frames", &viewerState.controls.frame, 0, int32(p.dc6.FramesPerDirection-1))
 			}
 
-			imgui.SliderInt("Scale", &viewerState.controls.scale, 1, 8)
+			const minScale, maxScale = 1, 8
+
+			imgui.SliderInt("Scale", &viewerState.controls.scale, minScale, maxScale)
 
 			imgui.EndGroup()
 		}),

--- a/hswidget/dccwidget/doc.go
+++ b/hswidget/dccwidget/doc.go
@@ -1,3 +1,2 @@
-// Package dccwidget contains stuff responsible for
-// viewing and editing DCC structures
+// Package dccwidget contains stuff responsible for viewing and editing the DCC data structure
 package dccwidget

--- a/hswidget/dccwidget/state.go
+++ b/hswidget/dccwidget/state.go
@@ -114,7 +114,7 @@ func (s *widgetState) Decode(data []byte) {
 		return
 	}
 
-	s.isPlaying = (isPlaying == 1)
+	s.isPlaying = isPlaying == 1
 
 	repeat, err := sr.ReadByte()
 	if err != nil {
@@ -122,7 +122,7 @@ func (s *widgetState) Decode(data []byte) {
 		return
 	}
 
-	s.repeat = (repeat == 1)
+	s.repeat = repeat == 1
 
 	s.tickTime, err = sr.ReadInt32()
 	if err != nil {

--- a/hswidget/dccwidget/widget.go
+++ b/hswidget/dccwidget/widget.go
@@ -105,7 +105,9 @@ func (p *widget) Build() {
 				imgui.SliderInt("Frames", &viewerState.controls.frame, 0, int32(p.dcc.FramesPerDirection-1))
 			}
 
-			imgui.SliderInt("Scale", &viewerState.controls.scale, 1, 8)
+			const minScale, maxScale = 1, 8
+
+			imgui.SliderInt("Scale", &viewerState.controls.scale, minScale, maxScale)
 
 			imgui.EndGroup()
 		}),

--- a/hswidget/doc.go
+++ b/hswidget/doc.go
@@ -1,2 +1,2 @@
-// Package hswidget contains widgets for each editor
+// Package hswidget contains a generic editor widget implementation, along with with concrete editor implementations.
 package hswidget

--- a/hswidget/ds1widget/doc.go
+++ b/hswidget/ds1widget/doc.go
@@ -1,3 +1,2 @@
-// Package ds1widget provides a giu.Widget implementation for viewing and editing
-// the DS1 files.
+// Package ds1widget provides a giu.Widget for viewing and editing the DS1 data structure.
 package ds1widget

--- a/hswidget/ds1widget/widget.go
+++ b/hswidget/ds1widget/widget.go
@@ -333,11 +333,10 @@ func (p *widget) makeObjectLayout(state *widgetState) giu.Layout {
 	}
 
 	if len(obj.Paths) > 0 {
-		l = append(
-			l,
-			giu.Dummy(1, 16),
-			p.makePathLayout(state, obj),
-		)
+		const spacerHeight = 16
+
+		vspace := giu.Dummy(1, spacerHeight)
+		l = append(l, vspace, p.makePathLayout(state, obj))
 	}
 
 	return l

--- a/hswidget/dt1widget/doc.go
+++ b/hswidget/dt1widget/doc.go
@@ -1,3 +1,2 @@
-// Package dt1widget contains data about dt1 widget, necessary to
-// edit and view dt1 file structure
+// Package dt1widget contains a giu widget implementation for viewing and editing the dt1 data structure
 package dt1widget

--- a/hswidget/dt1widget/state.go
+++ b/hswidget/dt1widget/state.go
@@ -91,7 +91,7 @@ func (s *widgetState) Decode(data []byte) {
 		return
 	}
 
-	s.showGrid = (showGrid == 1)
+	s.showGrid = showGrid == 1
 
 	showFloor, err := sr.ReadByte()
 	if err != nil {
@@ -100,7 +100,7 @@ func (s *widgetState) Decode(data []byte) {
 		return
 	}
 
-	s.showFloor = (showFloor == 1)
+	s.showFloor = showFloor == 1
 
 	showWall, err := sr.ReadByte()
 	if err != nil {
@@ -109,7 +109,7 @@ func (s *widgetState) Decode(data []byte) {
 		return
 	}
 
-	s.showWall = (showWall == 1)
+	s.showWall = showWall == 1
 
 	s.subtileFlag, err = sr.ReadInt32()
 	if err != nil {

--- a/hswidget/dt1widget/widget.go
+++ b/hswidget/dt1widget/widget.go
@@ -176,11 +176,6 @@ func (p *widget) makeTileTextures() {
 	p.setState(state)
 }
 
-func rangeByte(b byte, min, max float64) byte {
-	// nolint:gomnd // constant
-	return byte((float64(b)/255*(max-min) + min) * 255)
-}
-
 func (p *widget) makePixelBuffer(tile *d2dt1.Tile) (floorBuf, wallBuf []byte) {
 	tw, th := int(tile.Width), int(tile.Height)
 	if th < 0 {
@@ -219,9 +214,9 @@ func (p *widget) makePixelBuffer(tile *d2dt1.Tile) (floorBuf, wallBuf []byte) {
 			col := p.palette[floorVal]
 			r, g, b = col.R(), col.G(), col.B()
 		} else {
-			r = rangeByte(floorVal, 128, 256)
-			g = 0
-			b = rangeByte(rangeByte(floorVal, 0, 4), 128, 0)
+			r = floorVal
+			g = floorVal
+			b = floorVal
 		}
 
 		floorBuf[rPos] = r
@@ -240,9 +235,9 @@ func (p *widget) makePixelBuffer(tile *d2dt1.Tile) (floorBuf, wallBuf []byte) {
 			col := p.palette[wallVal]
 			r, g, b = col.R(), col.G(), col.B()
 		} else {
-			r = 0
-			g = rangeByte(wallVal, 64, 196)
-			b = rangeByte(rangeByte(floorVal, 0, 4), 128, 0)
+			r = wallVal
+			g = wallVal
+			b = wallVal
 		}
 
 		wallBuf[rPos] = r
@@ -477,6 +472,12 @@ func (p *widget) makeTileInfoTab(tile *d2dt1.Tile) giu.Layout {
 
 	roofHeight := int32(tile.RoofHeight)
 
+	const (
+		vspaceHeight = 4 // px
+	)
+
+	spacer := giu.Dummy(1, vspaceHeight)
+
 	return giu.Layout{
 		giu.Row(
 			giu.InputInt("##"+p.id+"inputWidth", &w).Size(inputIntW).OnChange(func() {
@@ -488,13 +489,13 @@ func (p *widget) makeTileInfoTab(tile *d2dt1.Tile) giu.Layout {
 			}),
 			giu.Label("pixels"),
 		),
-		giu.Dummy(1, 4),
+		spacer,
 
 		giu.Row(
 			giu.Label("Direction: "),
 			giu.InputInt("##"+p.id+"tileDirection", &tile.Direction).Size(inputIntW),
 		),
-		giu.Dummy(1, 4),
+		spacer,
 
 		giu.Row(
 			giu.Label("RoofHeight:"),
@@ -502,33 +503,27 @@ func (p *widget) makeTileInfoTab(tile *d2dt1.Tile) giu.Layout {
 				tile.RoofHeight = int16(roofHeight)
 			}),
 		),
-		giu.Dummy(1, 4),
+		spacer,
 
 		tileTypeInfo,
-		giu.Dummy(1, 4),
+		spacer,
 
 		giu.Row(
 			giu.Label("Style:"),
 			giu.InputInt("##"+p.id+"style", &tile.Style).Size(inputIntW),
 		),
-		giu.Dummy(1, 4),
+		spacer,
 
 		giu.Row(
 			giu.Label("Sequence:"),
 			giu.InputInt("##"+p.id+"sequence", &tile.Sequence).Size(inputIntW),
 		),
-		giu.Dummy(1, 4),
+		spacer,
 
 		giu.Row(
 			giu.Label("RarityFrameIndex:"),
 			giu.InputInt("##"+p.id+"rarityFrameIndex", &tile.RarityFrameIndex).Size(inputIntW),
 		),
-		// giu.Row(
-		//	giu.Label(fmt.Sprintf("SubTileFlags: %v", tile.SubTileFlags)),
-		// ),
-		// giu.Row(
-		//	giu.Label(fmt.Sprintf("Blocks: %v", tile.Blocks)),
-		// ),
 	}
 }
 
@@ -583,8 +578,13 @@ func (p *widget) makeSubtileFlags(state *widgetState, tile *d2dt1.Tile) giu.Layo
 		tile.Height *= -1
 	}
 
+	const (
+		maxSubtileIndex = 7
+		spacerHeight    = 4 // px
+	)
+
 	return giu.Layout{
-		giu.SliderInt("Subtile Type", &state.controls.subtileFlag, 0, 7),
+		giu.SliderInt("Subtile Type", &state.controls.subtileFlag, 0, maxSubtileIndex),
 		giu.Label(subTileString(state.controls.subtileFlag)),
 		giu.Label("Edit:"),
 		giu.Custom(func() {
@@ -601,7 +601,7 @@ func (p *widget) makeSubtileFlags(state *widgetState, tile *d2dt1.Tile) giu.Layo
 				giu.Row(layout...).Build()
 			}
 		}),
-		giu.Dummy(0, 4),
+		giu.Dummy(0, spacerHeight),
 		giu.Label("Preview:"),
 		p.makeSubTilePreview(tile, state),
 
@@ -665,7 +665,9 @@ func (p *widget) makeSubTilePreview(tile *d2dt1.Tile, state *widgetState) giu.La
 					hasFlag := (flag & (1 << state.controls.subtileFlag)) > 0
 
 					if hasFlag {
-						canvas.AddCircle(flagPoint, 3, col, 1)
+						const circleRadius = 3 // px
+
+						canvas.AddCircle(flagPoint, circleRadius, col, 1)
 					}
 				}
 

--- a/hswidget/fonttablewidget/doc.go
+++ b/hswidget/fonttablewidget/doc.go
@@ -1,3 +1,3 @@
-// Package fonttablewidget contains stuff responsible for
-// font table editor widget
+// Package fonttablewidget contains a giu widget implementation for viewing and editing the
+// font table (tbl) data structure.
 package fonttablewidget

--- a/hswidget/palettegrideditorwidget/doc.go
+++ b/hswidget/palettegrideditorwidget/doc.go
@@ -1,4 +1,3 @@
-// Package palettegrideditorwidget provides data for editin palette grid
-// it uses palettegridwidget to display palette.
-// when clicked on color, editor is started
+// Package palettegrideditorwidget provides a giu widget implementation of a palette editor, for viewing and editing
+// a palette.
 package palettegrideditorwidget

--- a/hswidget/palettegrideditorwidget/helpers.go
+++ b/hswidget/palettegrideditorwidget/helpers.go
@@ -24,16 +24,18 @@ func (p *PaletteGridEditorWidget) changeColor(state *widgetState) {
 
 // Hex2RGB converts haxadecimal color into r, g, b
 func Hex2RGB(hex string) (r, g, b uint8, err error) {
-	values, err := strconv.ParseUint(hex, 16, 32)
-	if err != nil {
-		return 0, 0, 0, fmt.Errorf("error parsing uint: %w", err)
-	}
-
 	const (
+		base    = 16
+		bitSize = 32
 		mask    = 0xFF
 		rOffset = 16
 		gOffset = 8
 	)
+
+	values, err := strconv.ParseUint(hex, base, bitSize)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("error parsing uint: %w", err)
+	}
 
 	r = uint8(values >> rOffset)
 	g = uint8((values >> gOffset) & mask)
@@ -43,7 +45,9 @@ func Hex2RGB(hex string) (r, g, b uint8, err error) {
 }
 
 func t2x(t int64) string {
-	result := strconv.FormatInt(t, 16)
+	const base = 16
+
+	result := strconv.FormatInt(t, base)
 	if len(result) == 1 {
 		result = "0" + result
 	}

--- a/hswidget/palettegrideditorwidget/widget.go
+++ b/hswidget/palettegrideditorwidget/widget.go
@@ -2,6 +2,7 @@ package palettegrideditorwidget
 
 import (
 	"log"
+	"math"
 
 	"github.com/ianling/giu"
 
@@ -137,7 +138,7 @@ func (p *PaletteGridEditorWidget) makeRGBField(id, label string, field *uint8, g
 				},
 			),
 		),
-		giu.SliderInt(id+"Slider", &f32, 0, 255).OnChange(func() {
+		giu.SliderInt(id+"Slider", &f32, 0, math.MaxUint8).OnChange(func() {
 			p.changeColor(state)
 			grid.UpdateColorTexture(state.idx)
 			if p.onChange != nil {

--- a/hswidget/palettegridwidget/helpers.go
+++ b/hswidget/palettegridwidget/helpers.go
@@ -7,16 +7,18 @@ import (
 
 // Hex2RGB converts haxadecimal color into r, g, b
 func Hex2RGB(hex string) (r, g, b uint8, err error) {
-	values, err := strconv.ParseUint(hex, 16, 32)
-	if err != nil {
-		return 0, 0, 0, fmt.Errorf("error parsing uint: %w", err)
-	}
-
 	const (
+		base    = 16
+		bitSize = 32
 		mask    = 0xFF
 		rOffset = 16
 		gOffset = 8
 	)
+
+	values, err := strconv.ParseUint(hex, base, bitSize)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("error parsing uint: %w", err)
+	}
 
 	r = uint8(values >> rOffset)
 	g = uint8((values >> gOffset) & mask)
@@ -26,7 +28,9 @@ func Hex2RGB(hex string) (r, g, b uint8, err error) {
 }
 
 func t2x(t int64) string {
-	result := strconv.FormatInt(t, 16)
+	const base = 16
+	result := strconv.FormatInt(t, base)
+
 	if len(result) == 1 {
 		result = "0" + result
 	}

--- a/hswidget/palettemapwidget/doc.go
+++ b/hswidget/palettemapwidget/doc.go
@@ -1,2 +1,3 @@
-// Package palettemapwidget provides PL2 eidtor
+// Package palettemapwidget provides a giu widget implementation of an editor for the
+// PL2 palette transform data structure.
 package palettemapwidget

--- a/hswidget/palettemapwidget/widget.go
+++ b/hswidget/palettemapwidget/widget.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	comboW           = 280
-	layoutW, layoutH = 475, 300
-	actionButtonW    = layoutW
+	comboW             = 280
+	layoutW, layoutH   = 475, 300
+	actionButtonW      = layoutW
+	numColorsInPalette = 256
 )
 
 type widget struct {
@@ -55,7 +56,7 @@ func (p *widget) buildViewer(state *widgetState) {
 		log.Print(err)
 	}
 
-	baseColors := make([]palettegridwidget.PaletteColor, 256)
+	baseColors := make([]palettegridwidget.PaletteColor, numColorsInPalette)
 
 	for n := range baseColors {
 		baseColors[n] = palettegridwidget.PaletteColor(&p.pl2.BasePalette.Colors[n])

--- a/hswidget/select_palette_widget.go
+++ b/hswidget/select_palette_widget.go
@@ -41,6 +41,7 @@ func NewSelectPaletteWidget(
 	closeCB func(),
 ) *SelectPaletteWidget {
 	result := &SelectPaletteWidget{
+		id:      id,
 		saveCB:  saveCB,
 		closeCB: closeCB,
 	}

--- a/hswindow/hsdialog/hsaboutdialog/aboutdialog.go
+++ b/hswindow/hsdialog/hsaboutdialog/aboutdialog.go
@@ -80,7 +80,8 @@ func Create(textureLoader hscommon.TextureLoader, regularFont, titleFont, fixedF
 	}
 
 	// set string's max length
-	text = strings.Join(hsutil.SplitIntoLinesWithMaxWidth(text, 70), "\n")
+	const maxColumns = 70
+	text = strings.Join(hsutil.SplitIntoLinesWithMaxWidth(text, maxColumns), "\n")
 	result.readme = text
 
 	return result, nil

--- a/hswindow/hsdialog/hsaboutdialog/aboutdialog.go
+++ b/hswindow/hsdialog/hsaboutdialog/aboutdialog.go
@@ -1,4 +1,4 @@
-// Package hsaboutdialog contains about dialog's data
+// Package hsaboutdialog provides the "About" window implementation, which shows information about hellspawner.
 package hsaboutdialog
 
 import (

--- a/hswindow/hsdialog/hsprojectpropertiesdialog/projectpropertiesdialog.go
+++ b/hswindow/hsdialog/hsprojectpropertiesdialog/projectpropertiesdialog.go
@@ -114,6 +114,9 @@ func (p *ProjectPropertiesDialog) Build() {
 
 					return false
 				}
+
+				const listItemHeight = 20
+
 				// list of `Selectable widgets`;
 				for i, mpq := range p.auxMPQNames {
 					i := i
@@ -132,7 +135,7 @@ func (p *ProjectPropertiesDialog) Build() {
 						}),
 						g.Selectable(mpq+"##"+"ProjectPropertiesSelectAuxMPQDialogIdx"+strconv.Itoa(i)).
 							Selected(isSelected).
-							Size(mainWindowW, 20).OnClick(func() {
+							Size(mainWindowW, listItemHeight).OnClick(func() {
 							if isSelected {
 								removeMPQ(i)
 							} else {
@@ -234,8 +237,10 @@ func (p *ProjectPropertiesDialog) Build() {
 			),
 			g.Row(
 				g.Custom(func() {
+					const halfOpacity = 0.5
+
 					if !canSave {
-						imgui.PushStyleVarFloat(imgui.StyleVarAlpha, 0.5)
+						imgui.PushStyleVarFloat(imgui.StyleVarAlpha, halfOpacity)
 					}
 				}),
 				g.Button("Save##ProjectPropertiesDialogSave").OnClick(p.onSaveClicked),

--- a/hswindow/hseditor/doc.go
+++ b/hswindow/hseditor/doc.go
@@ -1,2 +1,3 @@
-// Package hseditor contains editor's data
+// Package hseditor provides editors for the various file types. These generally take the form of
+// a window which displays a single widget, as well as some context-sensitive menu for the main menu bar.
 package hseditor

--- a/hswindow/hseditor/editor.go
+++ b/hswindow/hseditor/editor.go
@@ -64,29 +64,25 @@ func (e *Editor) Save(editor Saveable) {
 		return
 	}
 
-	if _, isSaveable := editor.(Saveable); isSaveable {
-		saveData := editor.GenerateSaveData()
-		if saveData == nil {
-			return
-		}
+	saveData := editor.GenerateSaveData()
+	if saveData == nil {
+		return
+	}
 
-		existingFileData, err := e.Path.GetFileBytes()
-		if err != nil {
-			fmt.Println("failed to read file before saving: ", err)
-			return
-		}
+	existingFileData, err := e.Path.GetFileBytes()
+	if err != nil {
+		fmt.Println("failed to read file before saving: ", err)
+		return
+	}
 
-		if bytes.Equal(saveData, existingFileData) {
-			// nothing to save
-			return
-		}
+	if bytes.Equal(saveData, existingFileData) {
+		// nothing to save
+		return
+	}
 
-		err = e.Path.WriteFile(saveData)
-		if err != nil {
-			fmt.Println("failed to save file: ", err)
-			return
-		}
-	} else {
+	err = e.Path.WriteFile(saveData)
+	if err != nil {
+		fmt.Println("failed to save file: ", err)
 		return
 	}
 }
@@ -98,13 +94,11 @@ func (e *Editor) HasChanges(editor Saveable) bool {
 		return false
 	}
 
-	if _, isSaveable := editor.(Saveable); isSaveable {
-		newData := editor.GenerateSaveData()
-		if newData != nil {
-			oldData, err := e.Path.GetFileBytes()
-			if err == nil {
-				return !bytes.Equal(oldData, newData)
-			}
+	newData := editor.GenerateSaveData()
+	if newData != nil {
+		oldData, err := e.Path.GetFileBytes()
+		if err == nil {
+			return !bytes.Equal(oldData, newData)
 		}
 	}
 

--- a/hswindow/hseditor/hscofeditor/cof_editor.go
+++ b/hswindow/hseditor/hscofeditor/cof_editor.go
@@ -31,7 +31,7 @@ type COFEditor struct {
 }
 
 // Create creates a new cof editor
-func Create(config *hsconfig.Config,
+func Create(_ *hsconfig.Config,
 	tl hscommon.TextureLoader,
 	pathEntry *hscommon.PathEntry,
 	state []byte,

--- a/hswindow/hseditor/hspaletteeditor/palette_editor.go
+++ b/hswindow/hseditor/hspaletteeditor/palette_editor.go
@@ -55,7 +55,9 @@ func Create(
 
 // Build builds a palette editor
 func (e *PaletteEditor) Build() {
-	col := make([]palettegridwidget.PaletteColor, 256)
+	const colorsPerPalette = 256
+
+	col := make([]palettegridwidget.PaletteColor, colorsPerPalette)
 	for n, i := range e.palette.GetColors() {
 		col[n] = palettegridwidget.PaletteColor(i)
 	}

--- a/hswindow/hseditor/hssoundeditor/soundeditor.go
+++ b/hswindow/hseditor/hssoundeditor/soundeditor.go
@@ -84,6 +84,10 @@ func (s *SoundEditor) Build() {
 	secondsCurrent := s.streamer.Position() / progressTimeModifier
 	secondsTotal := s.streamer.Len() / progressTimeModifier
 
+	const progressBarHeight = 24 // px
+
+	progress := float32(s.streamer.Position()) / float32(s.streamer.Len())
+
 	s.IsOpen(&s.Visible).
 		Flags(g.WindowFlagsNoResize).
 		Size(mainWindowW, mainWindowH).
@@ -91,7 +95,7 @@ func (s *SoundEditor) Build() {
 			g.Row(
 				hswidget.PlayPauseButton("##"+s.Path.GetUniqueID()+"playPause", &isPlaying, s.textureLoader).
 					OnPlayClicked(s.play).OnPauseClicked(s.stop).Size(btnSize, btnSize),
-				g.ProgressBar(float32(s.streamer.Position())/float32(s.streamer.Len())).Size(-1, 24).
+				g.ProgressBar(progress).Size(-1, progressBarHeight).
 					Overlay(fmt.Sprintf("%d:%02d / %d:%02d",
 						secondsCurrent/progressIndicatorModifier,
 						secondsCurrent%progressIndicatorModifier,

--- a/hswindow/hstoolwindow/hsconsole/console.go
+++ b/hswindow/hstoolwindow/hsconsole/console.go
@@ -1,4 +1,4 @@
-// Package hsconsole contains project's console
+// Package hsconsole provides a graphical console for logging output while the app is running.
 package hsconsole
 
 import (

--- a/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
+++ b/hswindow/hstoolwindow/hsmpqexplorer/mpqexplorer.go
@@ -1,4 +1,5 @@
-// Package hsmpqexplorer contains mpq explorer's data
+// Package hsmpqexplorer contains an implementation of a MPQ archive explorer,
+// which displays the archive contents as a tree.
 package hsmpqexplorer
 
 import (

--- a/hswindow/hstoolwindow/hsprojectexplorer/projectexplorer.go
+++ b/hswindow/hstoolwindow/hsprojectexplorer/projectexplorer.go
@@ -1,4 +1,4 @@
-// Package hsprojectexplorer contains project explorer's data
+// Package hsprojectexplorer provides a project explorer, for viewing project directories as trees.
 package hsprojectexplorer
 
 import (


### PR DESCRIPTION
In this PR are corrections to typo's, corrections to doc strings, and I've fixed all lint errors. Our build should be fixed for now.

I've also updated the `build.yml` to use go v1.16.5.