### PR TITLE
remove redundant hex2rgb func declarations (resolves #325)

### DIFF
--- a/hscommon/hsutil/hex_colors.go
+++ b/hscommon/hsutil/hex_colors.go
@@ -1,11 +1,11 @@
-package palettegridwidget
+package hsutil
 
 import (
 	"fmt"
 	"strconv"
 )
 
-// Hex2RGB converts haxadecimal color into r, g, b
+// Hex2RGB converts haxadecimal string color into r, g, b
 func Hex2RGB(hex string) (r, g, b uint8, err error) {
 	const (
 		base    = 16
@@ -29,8 +29,8 @@ func Hex2RGB(hex string) (r, g, b uint8, err error) {
 
 func t2x(t int64) string {
 	const base = 16
-	result := strconv.FormatInt(t, base)
 
+	result := strconv.FormatInt(t, base)
 	if len(result) == 1 {
 		result = "0" + result
 	}
@@ -38,7 +38,7 @@ func t2x(t int64) string {
 	return result
 }
 
-// RGB2Hex converts RGB into hexadecimal
+// RGB2Hex converts RGB color into hexadecimal string
 func RGB2Hex(red, green, blue uint8) string {
 	r := t2x(int64(red))
 	g := t2x(int64(green))

--- a/hswidget/palettegrideditorwidget/helpers.go
+++ b/hswidget/palettegrideditorwidget/helpers.go
@@ -1,10 +1,5 @@
 package palettegrideditorwidget
 
-import (
-	"fmt"
-	"strconv"
-)
-
 func (p *PaletteGridEditorWidget) changeColor(state *widgetState) {
 	const (
 		maxValue = 255
@@ -20,46 +15,4 @@ func (p *PaletteGridEditorWidget) changeColor(state *widgetState) {
 	rgba |= uint32(state.b) << bOffset
 	rgba |= uint32(maxValue) << aOffset
 	(*p.colors)[state.idx].SetRGBA(rgba)
-}
-
-// Hex2RGB converts haxadecimal color into r, g, b
-func Hex2RGB(hex string) (r, g, b uint8, err error) {
-	const (
-		base    = 16
-		bitSize = 32
-		mask    = 0xFF
-		rOffset = 16
-		gOffset = 8
-	)
-
-	values, err := strconv.ParseUint(hex, base, bitSize)
-	if err != nil {
-		return 0, 0, 0, fmt.Errorf("error parsing uint: %w", err)
-	}
-
-	r = uint8(values >> rOffset)
-	g = uint8((values >> gOffset) & mask)
-	b = uint8(values & mask)
-
-	return r, g, b, nil
-}
-
-func t2x(t int64) string {
-	const base = 16
-
-	result := strconv.FormatInt(t, base)
-	if len(result) == 1 {
-		result = "0" + result
-	}
-
-	return result
-}
-
-// RGB2Hex converts RGB into hexadecimal
-func RGB2Hex(red, green, blue uint8) string {
-	r := t2x(int64(red))
-	g := t2x(int64(green))
-	b := t2x(int64(blue))
-
-	return r + g + b
 }

--- a/hswidget/palettegrideditorwidget/widget.go
+++ b/hswidget/palettegrideditorwidget/widget.go
@@ -96,7 +96,7 @@ func (p *PaletteGridEditorWidget) buildEditor(grid *palettegridwidget.PaletteGri
 		giu.Row(
 			giu.Label("Hex: "),
 			giu.InputText("##"+p.id+"editHex", &state.hex).OnChange(func() {
-				r, g, b, err := Hex2RGB(state.hex)
+				r, g, b, err := hsutil.Hex2RGB(state.hex)
 				if err != nil {
 					log.Print("error: ", err)
 				}
@@ -134,7 +134,7 @@ func (p *PaletteGridEditorWidget) makeRGBField(id, label string, field *uint8, g
 					if p.onChange != nil {
 						p.onChange()
 					}
-					state.hex = RGB2Hex(state.r, state.g, state.b)
+					state.hex = hsutil.RGB2Hex(state.r, state.g, state.b)
 				},
 			),
 		),
@@ -144,7 +144,7 @@ func (p *PaletteGridEditorWidget) makeRGBField(id, label string, field *uint8, g
 			if p.onChange != nil {
 				p.onChange()
 			}
-			state.hex = RGB2Hex(state.r, state.g, state.b)
+			state.hex = hsutil.RGB2Hex(state.r, state.g, state.b)
 			hswidget.SetByteToInt(f32, field)
 		}),
 	}


### PR DESCRIPTION
placing utility functions that were declared in multiple widgets into `hscommon/hsutil`